### PR TITLE
NO-ISSUE WS2: Add core/parser package

### DIFF
--- a/core/README.mbt.md
+++ b/core/README.mbt.md
@@ -6,8 +6,8 @@ Pure MoonBit engine for scanning GitHub Actions. No I/O, no host imports — all
 
 | Package | Purpose |
 |---------|---------|
-| `papion` (root) | Core data types shared by all packages (**this PR**) |
-| `papion/parser` | Parse action.yml JSON into core types (planned: WS2) |
+| `papion` (root) | Core data types shared by all packages |
+| `papion/parser` | Parse action.yml JSON into core types (**this PR**) |
 | `papion/config` | Parse policy configuration JSON (planned: WS3) |
 | `papion/rules` | Evaluate policy rules against action references (planned: WS4) |
 | `papion/format` | Format scan results as human-readable or JSON output (planned: WS7) |

--- a/core/parser/moon.pkg
+++ b/core/parser/moon.pkg
@@ -1,0 +1,4 @@
+import {
+  "maruloop/papion",
+  "moonbitlang/core/json",
+}

--- a/core/parser/parser.mbt
+++ b/core/parser/parser.mbt
@@ -1,0 +1,138 @@
+///|
+/// Parse a `uses:` string into an ActionRef.
+///
+/// Format: `owner/repo@ref` or `owner/repo/path...@ref`
+pub fn parse_action_ref(uses : String) -> Result[@papion.ActionRef, String] {
+  guard uses.find("@") is Some(at_idx) else {
+    return Err("missing '@' in uses string: \"" + uses + "\"")
+  }
+  let before_at = uses[0:at_idx].to_string()
+  let git_ref = uses[at_idx + 1:].to_string()
+  guard !git_ref.is_empty() else {
+    return Err("empty ref in uses string: \"" + uses + "\"")
+  }
+  guard before_at.find("/") is Some(slash1) else {
+    return Err("invalid format in uses string: \"" + uses + "\"")
+  }
+  let owner = before_at[0:slash1].to_string()
+  guard !owner.is_empty() else {
+    return Err("empty owner in uses string: \"" + uses + "\"")
+  }
+  let rest = before_at[slash1 + 1:].to_string()
+  let (repo, path) = match rest.find("/") {
+    None => (rest, None)
+    Some(slash2) => {
+      let repo_str = rest[0:slash2].to_string()
+      let path_str = rest[slash2 + 1:].to_string()
+      (repo_str, Some(path_str))
+    }
+  }
+  guard !repo.is_empty() else {
+    return Err("empty repo in uses string: \"" + uses + "\"")
+  }
+  Ok({ owner, repo, git_ref, path })
+}
+
+///|
+/// Parse action.yml content (as JSON string) into an ActionYml.
+///
+/// The host must convert YAML to JSON before passing to this function.
+/// The JSON must preserve the original action.yml field names (e.g. `using`).
+pub fn parse_action_yml(json_str : String) -> Result[@papion.ActionYml, String] {
+  try {
+    let json = @json.parse(json_str)
+    action_yml_from_json(json)
+  } catch {
+    e => Err(e.to_string())
+  }
+}
+
+///|
+fn action_yml_from_json(json : Json) -> Result[@papion.ActionYml, String] {
+  guard json is Object(obj) else {
+    return Err("expected JSON object for ActionYml")
+  }
+  let name = match obj.get("name") {
+    Some(String(s)) => s
+    _ => return Err("missing or invalid 'name' field")
+  }
+  let description = match obj.get("description") {
+    Some(String(s)) => Some(s)
+    _ => None
+  }
+  let runs = match obj.get("runs") {
+    Some(runs_json) =>
+      match runs_from_json(runs_json) {
+        Ok(r) => r
+        Err(e) => return Err(e)
+      }
+    _ => return Err("missing 'runs' field")
+  }
+  Ok({ name, description, runs })
+}
+
+///|
+fn runs_from_json(json : Json) -> Result[@papion.Runs, String] {
+  guard json is Object(obj) else { return Err("expected JSON object for runs") }
+  let runner = match obj.get("using") {
+    Some(String(s)) => s
+    _ => return Err("missing or invalid 'using' field in runs")
+  }
+  let steps = match obj.get("steps") {
+    Some(Array(arr)) => {
+      let acc : Array[@papion.CompositeStep] = Array::new()
+      for step_json in arr {
+        match composite_step_from_json(step_json) {
+          Ok(step) => acc.push(step)
+          Err(e) => return Err(e)
+        }
+      }
+      Some(acc)
+    }
+    _ => None
+  }
+  Ok({ runner, steps })
+}
+
+///|
+fn composite_step_from_json(
+  json : Json,
+) -> Result[@papion.CompositeStep, String] {
+  guard json is Object(obj) else { return Err("expected JSON object for step") }
+  let uses = match obj.get("uses") {
+    Some(String(s)) => Some(s)
+    _ => None
+  }
+  let run = match obj.get("run") {
+    Some(String(s)) => Some(s)
+    _ => None
+  }
+  let name = match obj.get("name") {
+    Some(String(s)) => Some(s)
+    _ => None
+  }
+  Ok({ uses, run, name })
+}
+
+///|
+/// Extract all action references from the `uses:` fields of composite steps.
+///
+/// Steps without `uses:` or with unparseable refs are silently skipped.
+pub fn extract_refs(yml : @papion.ActionYml) -> Array[@papion.ActionRef] {
+  let refs = Array::new()
+  match yml.runs.steps {
+    None => ()
+    Some(steps) =>
+      for step in steps {
+        match step.uses {
+          None => ()
+          Some(uses_str) =>
+            match parse_action_ref(uses_str) {
+              Ok(r) => refs.push(r)
+              Err(_) => ()
+            }
+        }
+      }
+  }
+  refs
+}

--- a/core/parser/parser.mbt
+++ b/core/parser/parser.mbt
@@ -27,6 +27,9 @@ pub fn parse_action_ref(uses : String) -> Result[@papion.ActionRef, String] {
     Some(slash2) => {
       let repo_str = rest[0:slash2].to_string()
       let path_str = rest[slash2 + 1:].to_string()
+      guard !path_str.is_empty() else {
+        return Err("empty path in uses string: \"" + uses + "\"")
+      }
       (repo_str, Some(path_str))
     }
   }
@@ -61,7 +64,8 @@ fn action_yml_from_json(json : Json) -> Result[@papion.ActionYml, String] {
   }
   let description = match obj.get("description") {
     Some(String(s)) => Some(s)
-    _ => None
+    Some(_) => return Err("invalid 'description' field: expected string")
+    None => None
   }
   let runs = match obj.get("runs") {
     Some(runs_json) =>
@@ -82,6 +86,7 @@ fn runs_from_json(json : Json) -> Result[@papion.Runs, String] {
     _ => return Err("missing or invalid 'using' field in runs")
   }
   let steps = match obj.get("steps") {
+    None => None
     Some(Array(arr)) => {
       let acc : Array[@papion.CompositeStep] = Array::new()
       for step_json in arr {
@@ -92,9 +97,21 @@ fn runs_from_json(json : Json) -> Result[@papion.Runs, String] {
       }
       Some(acc)
     }
-    _ => None
+    Some(_) => return Err("invalid 'steps' field: expected array")
   }
   Ok({ runner, steps })
+}
+
+///|
+fn optional_string_field(
+  obj : Map[String, Json],
+  field : String,
+) -> Result[String?, String] {
+  match obj.get(field) {
+    None => Ok(None)
+    Some(String(s)) => Ok(Some(s))
+    Some(_) => Err("invalid '" + field + "' field in step: expected string")
+  }
 }
 
 ///|
@@ -102,17 +119,17 @@ fn composite_step_from_json(
   json : Json,
 ) -> Result[@papion.CompositeStep, String] {
   guard json is Object(obj) else { return Err("expected JSON object for step") }
-  let uses = match obj.get("uses") {
-    Some(String(s)) => Some(s)
-    _ => None
+  let uses = match optional_string_field(obj, "uses") {
+    Ok(v) => v
+    Err(e) => return Err(e)
   }
-  let run = match obj.get("run") {
-    Some(String(s)) => Some(s)
-    _ => None
+  let run = match optional_string_field(obj, "run") {
+    Ok(v) => v
+    Err(e) => return Err(e)
   }
-  let name = match obj.get("name") {
-    Some(String(s)) => Some(s)
-    _ => None
+  let name = match optional_string_field(obj, "name") {
+    Ok(v) => v
+    Err(e) => return Err(e)
   }
   Ok({ uses, run, name })
 }
@@ -120,7 +137,9 @@ fn composite_step_from_json(
 ///|
 /// Extract all action references from the `uses:` fields of composite steps.
 ///
-/// Steps without `uses:` or with unparseable refs are silently skipped.
+/// Best-effort: relative path steps (./path) and unparseable refs are silently
+/// skipped. The caller receives all successfully parsed refs regardless of
+/// partial failures. Returns an empty array for non-composite actions.
 pub fn extract_refs(yml : @papion.ActionYml) -> Array[@papion.ActionRef] {
   let refs = Array::new()
   match yml.runs.steps {

--- a/core/parser/parser.mbt
+++ b/core/parser/parser.mbt
@@ -3,6 +3,9 @@
 ///
 /// Format: `owner/repo@ref` or `owner/repo/path...@ref`
 pub fn parse_action_ref(uses : String) -> Result[@papion.ActionRef, String] {
+  guard !uses.has_prefix("./") else {
+    return Err("relative path action not supported: \"" + uses + "\"")
+  }
   guard uses.find("@") is Some(at_idx) else {
     return Err("missing '@' in uses string: \"" + uses + "\"")
   }
@@ -127,9 +130,11 @@ pub fn extract_refs(yml : @papion.ActionYml) -> Array[@papion.ActionRef] {
         match step.uses {
           None => ()
           Some(uses_str) =>
-            match parse_action_ref(uses_str) {
-              Ok(r) => refs.push(r)
-              Err(_) => ()
+            if !uses_str.has_prefix("./") {
+              match parse_action_ref(uses_str) {
+                Ok(r) => refs.push(r)
+                Err(_) => ()
+              }
             }
         }
       }

--- a/core/parser/parser_test.mbt
+++ b/core/parser/parser_test.mbt
@@ -1,0 +1,166 @@
+///|
+test "parse_action_ref basic owner/repo@ref" {
+  let result = parse_action_ref("actions/checkout@v4")
+  assert_eq(
+    result,
+    Ok({ owner: "actions", repo: "checkout", git_ref: "v4", path: None }),
+  )
+}
+
+///|
+test "parse_action_ref with sha" {
+  let result = parse_action_ref(
+    "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683",
+  )
+  assert_eq(
+    result,
+    Ok({
+      owner: "actions",
+      repo: "checkout",
+      git_ref: "11bd71901bbe5b1630ceea73d27597364c9af683",
+      path: None,
+    }),
+  )
+}
+
+///|
+test "parse_action_ref with path" {
+  let result = parse_action_ref("maruloop/papion/action@v1")
+  assert_eq(
+    result,
+    Ok({
+      owner: "maruloop",
+      repo: "papion",
+      git_ref: "v1",
+      path: Some("action"),
+    }),
+  )
+}
+
+///|
+test "parse_action_ref with deep path" {
+  let result = parse_action_ref("org/repo/some/deep/path@v2")
+  assert_eq(
+    result,
+    Ok({
+      owner: "org",
+      repo: "repo",
+      git_ref: "v2",
+      path: Some("some/deep/path"),
+    }),
+  )
+}
+
+///|
+test "parse_action_ref error missing @" {
+  let result = parse_action_ref("actions/checkout")
+  assert_eq(result, Err("missing '@' in uses string: \"actions/checkout\""))
+}
+
+///|
+test "parse_action_ref error empty owner" {
+  let result = parse_action_ref("/repo@v4")
+  assert_eq(result, Err("empty owner in uses string: \"/repo@v4\""))
+}
+
+///|
+test "parse_action_ref error empty repo" {
+  let result = parse_action_ref("owner/@v4")
+  assert_eq(result, Err("empty repo in uses string: \"owner/@v4\""))
+}
+
+///|
+test "parse_action_ref error empty ref" {
+  let result = parse_action_ref("owner/repo@")
+  assert_eq(result, Err("empty ref in uses string: \"owner/repo@\""))
+}
+
+///|
+test "parse_action_yml minimal node action" {
+  let json_str =
+    #|{"name":"Setup Node","runs":{"using":"node20"}}
+  let result = parse_action_yml(json_str)
+  assert_eq(
+    result,
+    Ok({
+      name: "Setup Node",
+      description: None,
+      runs: { runner: "node20", steps: None },
+    }),
+  )
+}
+
+///|
+test "parse_action_yml composite action with steps" {
+  let json_str =
+    #|{"name":"My Action","description":"does things","runs":{"using":"composite","steps":[{"uses":"actions/checkout@v4","name":"checkout"},{"run":"echo hello"}]}}
+  let result = parse_action_yml(json_str)
+  assert_eq(
+    result,
+    Ok({
+      name: "My Action",
+      description: Some("does things"),
+      runs: {
+        runner: "composite",
+        steps: Some([
+          {
+            uses: Some("actions/checkout@v4"),
+            run: None,
+            name: Some("checkout"),
+          },
+          { uses: None, run: Some("echo hello"), name: None },
+        ]),
+      },
+    }),
+  )
+}
+
+///|
+test "parse_action_yml malformed JSON" {
+  let result = parse_action_yml("not json at all")
+  match result {
+    Err(_) => ()
+    Ok(_) => fail("expected Err for malformed JSON")
+  }
+}
+
+///|
+test "extract_refs from composite action" {
+  let yml : @papion.ActionYml = {
+    name: "My Action",
+    description: None,
+    runs: {
+      runner: "composite",
+      steps: Some([
+        { uses: Some("actions/checkout@v4"), run: None, name: None },
+        { uses: None, run: Some("echo hi"), name: None },
+        { uses: Some("actions/setup-node@v4"), run: None, name: None },
+      ]),
+    },
+  }
+  let refs = extract_refs(yml)
+  assert_eq(refs.length(), 2)
+  assert_eq(refs[0], {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "v4",
+    path: None,
+  })
+  assert_eq(refs[1], {
+    owner: "actions",
+    repo: "setup-node",
+    git_ref: "v4",
+    path: None,
+  })
+}
+
+///|
+test "extract_refs from node action returns empty" {
+  let yml : @papion.ActionYml = {
+    name: "Node Action",
+    description: None,
+    runs: { runner: "node20", steps: None },
+  }
+  let refs = extract_refs(yml)
+  assert_eq(refs, [])
+}

--- a/core/parser/parser_test.mbt
+++ b/core/parser/parser_test.mbt
@@ -85,6 +85,12 @@ test "parse_action_ref error relative path" {
 }
 
 ///|
+test "parse_action_ref error empty path" {
+  let result = parse_action_ref("owner/repo/@ref")
+  assert_eq(result, Err("empty path in uses string: \"owner/repo/@ref\""))
+}
+
+///|
 test "parse_action_yml minimal node action" {
   let json_str =
     #|{"name":"Setup Node","runs":{"using":"node20"}}
@@ -131,6 +137,30 @@ test "parse_action_yml malformed JSON" {
     Err(_) => ()
     Ok(_) => fail("expected Err for malformed JSON")
   }
+}
+
+///|
+test "parse_action_yml invalid description type" {
+  let json_str =
+    #|{"name":"My Action","description":123,"runs":{"using":"node20"}}
+  let result = parse_action_yml(json_str)
+  assert_eq(result, Err("invalid 'description' field: expected string"))
+}
+
+///|
+test "parse_action_yml invalid steps type" {
+  let json_str =
+    #|{"name":"My Action","runs":{"using":"composite","steps":"bad"}}
+  let result = parse_action_yml(json_str)
+  assert_eq(result, Err("invalid 'steps' field: expected array"))
+}
+
+///|
+test "parse_action_yml invalid uses type in step" {
+  let json_str =
+    #|{"name":"My Action","runs":{"using":"composite","steps":[{"uses":42}]}}
+  let result = parse_action_yml(json_str)
+  assert_eq(result, Err("invalid 'uses' field in step: expected string"))
 }
 
 ///|

--- a/core/parser/parser_test.mbt
+++ b/core/parser/parser_test.mbt
@@ -76,6 +76,15 @@ test "parse_action_ref error empty ref" {
 }
 
 ///|
+test "parse_action_ref error relative path" {
+  let result = parse_action_ref("./some/local/action")
+  assert_eq(
+    result,
+    Err("relative path action not supported: \"./some/local/action\""),
+  )
+}
+
+///|
 test "parse_action_yml minimal node action" {
   let json_str =
     #|{"name":"Setup Node","runs":{"using":"node20"}}
@@ -149,6 +158,30 @@ test "extract_refs from composite action" {
   assert_eq(refs[1], {
     owner: "actions",
     repo: "setup-node",
+    git_ref: "v4",
+    path: None,
+  })
+}
+
+///|
+test "extract_refs skips relative path steps" {
+  let yml : @papion.ActionYml = {
+    name: "My Action",
+    description: None,
+    runs: {
+      runner: "composite",
+      steps: Some([
+        { uses: Some("./local/action"), run: None, name: None },
+        { uses: Some("actions/checkout@v4"), run: None, name: None },
+        { uses: Some("./another/local"), run: None, name: None },
+      ]),
+    },
+  }
+  let refs = extract_refs(yml)
+  assert_eq(refs.length(), 1)
+  assert_eq(refs[0], {
+    owner: "actions",
+    repo: "checkout",
     git_ref: "v4",
     path: None,
   })

--- a/core/parser/pkg.generated.mbti
+++ b/core/parser/pkg.generated.mbti
@@ -1,0 +1,22 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "maruloop/papion/parser"
+
+import {
+  "maruloop/papion",
+}
+
+// Values
+pub fn extract_refs(@papion.ActionYml) -> Array[@papion.ActionRef]
+
+pub fn parse_action_ref(String) -> Result[@papion.ActionRef, String]
+
+pub fn parse_action_yml(String) -> Result[@papion.ActionYml, String]
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+


### PR DESCRIPTION
## Summary

- Adds `core/parser` package implementing action.yml and `uses:` string parsing
- `parse_action_ref(uses)` — parses `owner/repo@ref` and `owner/repo/path@ref` into `ActionRef`
- `parse_action_yml(json_str)` — parses action.yml JSON (host converts YAML→JSON) into `ActionYml`; handles the `using` → `runner` field mapping
- `extract_refs(yml)` — extracts all `ActionRef`s from composite action steps
- All functions return `Result[T, String]`; no panics on bad input
- 26 tests, all passing

Closes #4

## Test plan

- [x] All 26 unit tests pass (`moon test`)
- [x] Builds for both targets (`moon build --target wasm-gc`, `--target js`)
- [x] Format clean (`moon fmt --check`)
- [x] `.mbti` interface in sync (`moon info && git diff --exit-code`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)