### PR TITLE
NO-ISSUE WS3: Add core/config package

### DIFF
--- a/core/README.mbt.md
+++ b/core/README.mbt.md
@@ -7,8 +7,8 @@ Pure MoonBit engine for scanning GitHub Actions. No I/O, no host imports — all
 | Package | Purpose |
 |---------|---------|
 | `papion` (root) | Core data types shared by all packages |
-| `papion/parser` | Parse action.yml JSON into core types (**this PR**) |
-| `papion/config` | Parse policy configuration JSON (planned: WS3) |
+| `papion/parser` | Parse action.yml JSON into core types |
+| `papion/config` | Parse policy configuration JSON, glob matching for allowed/disallowed lists (**this PR**) |
 | `papion/rules` | Evaluate policy rules against action references (planned: WS4) |
 | `papion/format` | Format scan results as human-readable or JSON output (planned: WS7) |
 | `papion/engine` | Orchestrate a full scan (WASM entry point) (planned: WS5) |

--- a/core/config/config.mbt
+++ b/core/config/config.mbt
@@ -1,0 +1,79 @@
+///|
+/// Parse a policy configuration JSON string into a Policy.
+///
+/// The host converts TOML to JSON before passing to this function.
+/// Missing fields use defaults: sha_pinning=true, allowed=[], disallowed=[].
+pub fn parse_policy(json_str : String) -> Result[@papion.Policy, String] {
+  try {
+    let json = @json.parse(json_str)
+    guard json is Object(obj) else {
+      return Err("expected JSON object for Policy")
+    }
+    let sha_pinning = match obj.get("sha_pinning") {
+      Some(True) => true
+      Some(False) => false
+      None => true
+      Some(_) => return Err("invalid 'sha_pinning' field: expected boolean")
+    }
+    let allowed = match obj.get("allowed") {
+      None => []
+      Some(Array(arr)) => {
+        let acc : Array[String] = Array::new()
+        for item in arr {
+          match item {
+            String(s) => acc.push(s)
+            _ => return Err("invalid entry in 'allowed': expected string")
+          }
+        }
+        acc
+      }
+      Some(_) => return Err("invalid 'allowed' field: expected array")
+    }
+    let disallowed = match obj.get("disallowed") {
+      None => []
+      Some(Array(arr)) => {
+        let acc : Array[String] = Array::new()
+        for item in arr {
+          match item {
+            String(s) => acc.push(s)
+            _ => return Err("invalid entry in 'disallowed': expected string")
+          }
+        }
+        acc
+      }
+      Some(_) => return Err("invalid 'disallowed' field: expected array")
+    }
+    Ok({ sha_pinning, allowed, disallowed })
+  } catch {
+    e => Err(e.to_string())
+  }
+}
+
+///|
+/// Returns true if the action ref is allowed by the policy.
+///
+/// If the allowed list is empty, all refs are allowed (pass-all).
+/// Otherwise, the ref must match at least one pattern.
+/// Matching is against "owner/repo" (case-insensitive).
+pub fn matches_allowed(
+  policy : @papion.Policy,
+  action_ref : @papion.ActionRef,
+) -> Bool {
+  if policy.allowed.is_empty() {
+    return true
+  }
+  let target = action_ref.owner + "/" + action_ref.repo
+  policy.allowed.iter().any(fn(pattern) { glob_match(pattern, target) })
+}
+
+///|
+/// Returns true if the action ref is disallowed by the policy.
+///
+/// Matching is against "owner/repo" (case-insensitive).
+pub fn matches_disallowed(
+  policy : @papion.Policy,
+  action_ref : @papion.ActionRef,
+) -> Bool {
+  let target = action_ref.owner + "/" + action_ref.repo
+  policy.disallowed.iter().any(fn(pattern) { glob_match(pattern, target) })
+}

--- a/core/config/config.mbt
+++ b/core/config/config.mbt
@@ -12,8 +12,9 @@ pub fn parse_policy(json_str : String) -> Result[@papion.Policy, String] {
       return Err("expected JSON object for Policy")
     }
     let obj = match obj.get("policy") {
+      None => obj
       Some(Object(inner)) => inner
-      _ => obj
+      Some(_) => return Err("invalid 'policy' field: expected object")
     }
     let sha_pinning = match obj.get("sha_pinning") {
       Some(True) => true
@@ -29,7 +30,9 @@ pub fn parse_policy(json_str : String) -> Result[@papion.Policy, String] {
           match item {
             String(s) => {
               if s.length() > max_pattern_len {
-                return Err("pattern too long in 'allowed': \{s}")
+                return Err(
+                  "pattern too long in 'allowed': \{s.length()} chars (max \{max_pattern_len})",
+                )
               }
               acc.push(s.to_lower())
             }
@@ -48,7 +51,9 @@ pub fn parse_policy(json_str : String) -> Result[@papion.Policy, String] {
           match item {
             String(s) => {
               if s.length() > max_pattern_len {
-                return Err("pattern too long in 'disallowed': \{s}")
+                return Err(
+                  "pattern too long in 'disallowed': \{s.length()} chars (max \{max_pattern_len})",
+                )
               }
               acc.push(s.to_lower())
             }
@@ -71,6 +76,7 @@ pub fn parse_policy(json_str : String) -> Result[@papion.Policy, String] {
 /// If the allowed list is empty, all refs are allowed (pass-all).
 /// Otherwise, the ref must match at least one pattern.
 /// Matching is against "owner/repo" (case-insensitive).
+/// Patterns in policy.allowed must be pre-normalized to lowercase (use parse_policy).
 pub fn matches_allowed(
   policy : @papion.Policy,
   action_ref : @papion.ActionRef,
@@ -86,6 +92,7 @@ pub fn matches_allowed(
 /// Returns true if the action ref is disallowed by the policy.
 ///
 /// Matching is against "owner/repo" (case-insensitive).
+/// Patterns in policy.disallowed must be pre-normalized to lowercase (use parse_policy).
 pub fn matches_disallowed(
   policy : @papion.Policy,
   action_ref : @papion.ActionRef,

--- a/core/config/config.mbt
+++ b/core/config/config.mbt
@@ -62,8 +62,10 @@ pub fn matches_allowed(
   if policy.allowed.is_empty() {
     return true
   }
-  let target = action_ref.owner + "/" + action_ref.repo
-  policy.allowed.iter().any(fn(pattern) { glob_match(pattern, target) })
+  let target = (action_ref.owner + "/" + action_ref.repo).to_lower()
+  policy.allowed
+  .iter()
+  .any(fn(pattern) { glob_match_lowered(pattern.to_lower(), target) })
 }
 
 ///|
@@ -74,6 +76,8 @@ pub fn matches_disallowed(
   policy : @papion.Policy,
   action_ref : @papion.ActionRef,
 ) -> Bool {
-  let target = action_ref.owner + "/" + action_ref.repo
-  policy.disallowed.iter().any(fn(pattern) { glob_match(pattern, target) })
+  let target = (action_ref.owner + "/" + action_ref.repo).to_lower()
+  policy.disallowed
+  .iter()
+  .any(fn(pattern) { glob_match_lowered(pattern.to_lower(), target) })
 }

--- a/core/config/config.mbt
+++ b/core/config/config.mbt
@@ -9,6 +9,10 @@ pub fn parse_policy(json_str : String) -> Result[@papion.Policy, String] {
     guard json is Object(obj) else {
       return Err("expected JSON object for Policy")
     }
+    let obj = match obj.get("policy") {
+      Some(Object(inner)) => inner
+      _ => obj
+    }
     let sha_pinning = match obj.get("sha_pinning") {
       Some(True) => true
       Some(False) => false

--- a/core/config/config.mbt
+++ b/core/config/config.mbt
@@ -3,6 +3,8 @@
 ///
 /// The host converts TOML to JSON before passing to this function.
 /// Missing fields use defaults: sha_pinning=true, allowed=[], disallowed=[].
+/// Returns Err if any pattern exceeds 256 characters.
+/// Patterns are normalized to lowercase during parsing.
 pub fn parse_policy(json_str : String) -> Result[@papion.Policy, String] {
   try {
     let json = @json.parse(json_str)
@@ -25,7 +27,12 @@ pub fn parse_policy(json_str : String) -> Result[@papion.Policy, String] {
         let acc : Array[String] = Array::new()
         for item in arr {
           match item {
-            String(s) => acc.push(s)
+            String(s) => {
+              if s.length() > max_pattern_len {
+                return Err("pattern too long in 'allowed': \{s}")
+              }
+              acc.push(s.to_lower())
+            }
             _ => return Err("invalid entry in 'allowed': expected string")
           }
         }
@@ -39,7 +46,12 @@ pub fn parse_policy(json_str : String) -> Result[@papion.Policy, String] {
         let acc : Array[String] = Array::new()
         for item in arr {
           match item {
-            String(s) => acc.push(s)
+            String(s) => {
+              if s.length() > max_pattern_len {
+                return Err("pattern too long in 'disallowed': \{s}")
+              }
+              acc.push(s.to_lower())
+            }
             _ => return Err("invalid entry in 'disallowed': expected string")
           }
         }
@@ -67,9 +79,7 @@ pub fn matches_allowed(
     return true
   }
   let target = (action_ref.owner + "/" + action_ref.repo).to_lower()
-  policy.allowed
-  .iter()
-  .any(fn(pattern) { glob_match_lowered(pattern.to_lower(), target) })
+  policy.allowed.iter().any(fn(pattern) { glob_match_lowered(pattern, target) })
 }
 
 ///|
@@ -83,5 +93,5 @@ pub fn matches_disallowed(
   let target = (action_ref.owner + "/" + action_ref.repo).to_lower()
   policy.disallowed
   .iter()
-  .any(fn(pattern) { glob_match_lowered(pattern.to_lower(), target) })
+  .any(fn(pattern) { glob_match_lowered(pattern, target) })
 }

--- a/core/config/config_test.mbt
+++ b/core/config/config_test.mbt
@@ -102,6 +102,16 @@ test "parse_policy nested policy key full config" {
 }
 
 ///|
+test "parse_policy rejects non-object policy key" {
+  let json_str =
+    #|{"policy":[]}
+  match parse_policy(json_str) {
+    Err(_) => ()
+    Ok(_) => fail("expected Err for non-object policy key")
+  }
+}
+
+///|
 test "parse_policy normalizes patterns to lowercase" {
   let json_str =
     #|{"allowed":["Actions/*","GitHub/*"],"disallowed":["Bad-Org/Unsafe"]}

--- a/core/config/config_test.mbt
+++ b/core/config/config_test.mbt
@@ -87,6 +87,29 @@ test "parse_policy rejects non-string entry in disallowed" {
 }
 
 ///|
+test "parse_policy nested policy key full config" {
+  let json_str =
+    #|{"policy":{"sha_pinning":false,"allowed":["actions/*"],"disallowed":["bad-org/unsafe"]}}
+  let result = parse_policy(json_str)
+  assert_eq(
+    result,
+    Ok({
+      sha_pinning: false,
+      allowed: ["actions/*"],
+      disallowed: ["bad-org/unsafe"],
+    }),
+  )
+}
+
+///|
+test "parse_policy nested policy key empty object uses defaults" {
+  let json_str =
+    #|{"policy":{}}
+  let result = parse_policy(json_str)
+  assert_eq(result, Ok({ sha_pinning: true, allowed: [], disallowed: [] }))
+}
+
+///|
 test "matches_allowed empty list passes all" {
   let policy : @papion.Policy = {
     sha_pinning: true,

--- a/core/config/config_test.mbt
+++ b/core/config/config_test.mbt
@@ -102,6 +102,41 @@ test "parse_policy nested policy key full config" {
 }
 
 ///|
+test "parse_policy normalizes patterns to lowercase" {
+  let json_str =
+    #|{"allowed":["Actions/*","GitHub/*"],"disallowed":["Bad-Org/Unsafe"]}
+  let result = parse_policy(json_str)
+  assert_eq(
+    result,
+    Ok({
+      sha_pinning: true,
+      allowed: ["actions/*", "github/*"],
+      disallowed: ["bad-org/unsafe"],
+    }),
+  )
+}
+
+///|
+test "parse_policy rejects overlong pattern in allowed" {
+  let long_pattern = String::make(257, 'a')
+  let json_str = "{\"allowed\":[\"\{long_pattern}\"]}"
+  match parse_policy(json_str) {
+    Err(_) => ()
+    Ok(_) => fail("expected Err for overlong allowed pattern")
+  }
+}
+
+///|
+test "parse_policy rejects overlong pattern in disallowed" {
+  let long_pattern = String::make(257, 'a')
+  let json_str = "{\"disallowed\":[\"\{long_pattern}\"]}"
+  match parse_policy(json_str) {
+    Err(_) => ()
+    Ok(_) => fail("expected Err for overlong disallowed pattern")
+  }
+}
+
+///|
 test "parse_policy nested policy key empty object uses defaults" {
   let json_str =
     #|{"policy":{}}
@@ -142,15 +177,15 @@ test "matches_allowed with matching pattern" {
 }
 
 ///|
-test "matches_allowed case-insensitive" {
+test "matches_allowed case-insensitive owner in target" {
   let policy : @papion.Policy = {
     sha_pinning: true,
-    allowed: ["Actions/*"],
+    allowed: ["actions/*"],
     disallowed: [],
   }
   let action_ref : @papion.ActionRef = {
-    owner: "actions",
-    repo: "checkout",
+    owner: "Actions",
+    repo: "Checkout",
     git_ref: "v4",
     path: None,
   }
@@ -190,15 +225,15 @@ test "matches_disallowed with matching pattern" {
 }
 
 ///|
-test "matches_disallowed case-insensitive" {
+test "matches_disallowed case-insensitive owner in target" {
   let policy : @papion.Policy = {
     sha_pinning: true,
     allowed: [],
-    disallowed: ["Bad-Org/*"],
+    disallowed: ["bad-org/*"],
   }
   let action_ref : @papion.ActionRef = {
-    owner: "bad-org",
-    repo: "evil-action",
+    owner: "Bad-Org",
+    repo: "Evil-Action",
     git_ref: "v1",
     path: None,
   }

--- a/core/config/config_test.mbt
+++ b/core/config/config_test.mbt
@@ -1,0 +1,141 @@
+///|
+test "parse_policy full config" {
+  let json_str =
+    #|{"sha_pinning":false,"allowed":["actions/*","github/*"],"disallowed":["bad-org/unsafe"]}
+  let result = parse_policy(json_str)
+  assert_eq(
+    result,
+    Ok({
+      sha_pinning: false,
+      allowed: ["actions/*", "github/*"],
+      disallowed: ["bad-org/unsafe"],
+    }),
+  )
+}
+
+///|
+test "parse_policy defaults on empty object" {
+  let result = parse_policy("{}")
+  assert_eq(result, Ok({ sha_pinning: true, allowed: [], disallowed: [] }))
+}
+
+///|
+test "parse_policy malformed JSON" {
+  let result = parse_policy("not json")
+  match result {
+    Err(_) => ()
+    Ok(_) => fail("expected Err for malformed JSON")
+  }
+}
+
+///|
+test "matches_allowed empty list passes all" {
+  let policy : @papion.Policy = {
+    sha_pinning: true,
+    allowed: [],
+    disallowed: [],
+  }
+  let action_ref : @papion.ActionRef = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "v4",
+    path: None,
+  }
+  assert_eq(matches_allowed(policy, action_ref), true)
+}
+
+///|
+test "matches_allowed with matching pattern" {
+  let policy : @papion.Policy = {
+    sha_pinning: true,
+    allowed: ["actions/*"],
+    disallowed: [],
+  }
+  let action_ref : @papion.ActionRef = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "v4",
+    path: None,
+  }
+  assert_eq(matches_allowed(policy, action_ref), true)
+}
+
+///|
+test "matches_allowed case-insensitive" {
+  let policy : @papion.Policy = {
+    sha_pinning: true,
+    allowed: ["Actions/*"],
+    disallowed: [],
+  }
+  let action_ref : @papion.ActionRef = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "v4",
+    path: None,
+  }
+  assert_eq(matches_allowed(policy, action_ref), true)
+}
+
+///|
+test "matches_allowed no match returns false" {
+  let policy : @papion.Policy = {
+    sha_pinning: true,
+    allowed: ["github/*"],
+    disallowed: [],
+  }
+  let action_ref : @papion.ActionRef = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "v4",
+    path: None,
+  }
+  assert_eq(matches_allowed(policy, action_ref), false)
+}
+
+///|
+test "matches_disallowed with matching pattern" {
+  let policy : @papion.Policy = {
+    sha_pinning: true,
+    allowed: [],
+    disallowed: ["bad-org/*"],
+  }
+  let action_ref : @papion.ActionRef = {
+    owner: "bad-org",
+    repo: "evil-action",
+    git_ref: "v1",
+    path: None,
+  }
+  assert_eq(matches_disallowed(policy, action_ref), true)
+}
+
+///|
+test "matches_disallowed case-insensitive" {
+  let policy : @papion.Policy = {
+    sha_pinning: true,
+    allowed: [],
+    disallowed: ["Bad-Org/*"],
+  }
+  let action_ref : @papion.ActionRef = {
+    owner: "bad-org",
+    repo: "evil-action",
+    git_ref: "v1",
+    path: None,
+  }
+  assert_eq(matches_disallowed(policy, action_ref), true)
+}
+
+///|
+test "matches_disallowed no match returns false" {
+  let policy : @papion.Policy = {
+    sha_pinning: true,
+    allowed: [],
+    disallowed: ["other-org/*"],
+  }
+  let action_ref : @papion.ActionRef = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "v4",
+    path: None,
+  }
+  assert_eq(matches_disallowed(policy, action_ref), false)
+}

--- a/core/config/config_test.mbt
+++ b/core/config/config_test.mbt
@@ -29,6 +29,64 @@ test "parse_policy malformed JSON" {
 }
 
 ///|
+test "parse_policy rejects non-object top-level JSON" {
+  match parse_policy("[]") {
+    Err(_) => ()
+    Ok(_) => fail("expected Err for non-object top-level JSON")
+  }
+}
+
+///|
+test "parse_policy rejects non-bool sha_pinning" {
+  let json_str =
+    #|{"sha_pinning":"false"}
+  match parse_policy(json_str) {
+    Err(_) => ()
+    Ok(_) => fail("expected Err for non-bool sha_pinning")
+  }
+}
+
+///|
+test "parse_policy rejects non-array allowed" {
+  let json_str =
+    #|{"allowed":"actions/*"}
+  match parse_policy(json_str) {
+    Err(_) => ()
+    Ok(_) => fail("expected Err for non-array allowed")
+  }
+}
+
+///|
+test "parse_policy rejects non-array disallowed" {
+  let json_str =
+    #|{"disallowed":"bad-org/unsafe"}
+  match parse_policy(json_str) {
+    Err(_) => ()
+    Ok(_) => fail("expected Err for non-array disallowed")
+  }
+}
+
+///|
+test "parse_policy rejects non-string entry in allowed" {
+  let json_str =
+    #|{"allowed":["actions/*",1]}
+  match parse_policy(json_str) {
+    Err(_) => ()
+    Ok(_) => fail("expected Err for non-string entry in allowed")
+  }
+}
+
+///|
+test "parse_policy rejects non-string entry in disallowed" {
+  let json_str =
+    #|{"disallowed":["bad-org/unsafe",false]}
+  match parse_policy(json_str) {
+    Err(_) => ()
+    Ok(_) => fail("expected Err for non-string entry in disallowed")
+  }
+}
+
+///|
 test "matches_allowed empty list passes all" {
   let policy : @papion.Policy = {
     sha_pinning: true,

--- a/core/config/glob.mbt
+++ b/core/config/glob.mbt
@@ -1,11 +1,31 @@
+// Maximum pattern length to guard against pathological backtracking.
+
+///|
+let max_pattern_len : Int = 256
+
 ///|
 /// Match a glob pattern against text. Case-insensitive.
 ///
 /// Wildcards:
 /// - `*`  matches any sequence of non-`/` characters (single segment)
 /// - `**` matches any sequence of characters including `/`
+///
+/// Returns false if pattern exceeds 256 characters.
 pub fn glob_match(pattern : String, text : String) -> Bool {
+  if pattern.length() > max_pattern_len {
+    return false
+  }
   glob_match_view(pattern.to_lower()[:], text.to_lower()[:])
+}
+
+///|
+/// Like `glob_match` but assumes both pattern and text are already lowercased.
+/// Skips the `to_lower` allocation for callers that lowercase once up front.
+pub fn glob_match_lowered(pattern : String, text : String) -> Bool {
+  if pattern.length() > max_pattern_len {
+    return false
+  }
+  glob_match_view(pattern[:], text[:])
 }
 
 ///|

--- a/core/config/glob.mbt
+++ b/core/config/glob.mbt
@@ -1,0 +1,54 @@
+///|
+/// Match a glob pattern against text. Case-insensitive.
+///
+/// Wildcards:
+/// - `*`  matches any sequence of non-`/` characters (single segment)
+/// - `**` matches any sequence of characters including `/`
+pub fn glob_match(pattern : String, text : String) -> Bool {
+  glob_match_view(pattern.to_lower()[:], text.to_lower()[:])
+}
+
+///|
+fn glob_match_view(pattern : StringView, text : StringView) -> Bool {
+  if pattern.is_empty() {
+    return text.is_empty()
+  }
+  // Check for ** at current position
+  if pattern.has_prefix("**") {
+    let rest_pattern = pattern[2:]
+    // ** matches zero or more characters — try matching rest at every position
+    if glob_match_view(rest_pattern, text) {
+      return true
+    }
+    for i in 1..<=text.length() {
+      if glob_match_view(rest_pattern, text[i:]) {
+        return true
+      }
+    }
+    return false
+  }
+  // Check for * at current position
+  if pattern.has_prefix("*") {
+    let rest_pattern = pattern[1:]
+    // * matches zero or more non-slash characters
+    let max = match text.find("/") {
+      Some(slash) => slash
+      None => text.length()
+    }
+    for i in 0..<=max {
+      if glob_match_view(rest_pattern, text[i:]) {
+        return true
+      }
+    }
+    return false
+  }
+  // Literal character: must match
+  if text.is_empty() {
+    return false
+  }
+  if pattern[0:1] == text[0:1] {
+    glob_match_view(pattern[1:], text[1:])
+  } else {
+    false
+  }
+}

--- a/core/config/glob_test.mbt
+++ b/core/config/glob_test.mbt
@@ -1,0 +1,66 @@
+///|
+test "glob exact match" {
+  assert_eq(glob_match("actions/checkout", "actions/checkout"), true)
+}
+
+///|
+test "glob exact match case-insensitive" {
+  assert_eq(glob_match("Actions/Checkout", "actions/checkout"), true)
+  assert_eq(glob_match("actions/checkout", "Actions/Checkout"), true)
+}
+
+///|
+test "glob exact no match" {
+  assert_eq(glob_match("actions/checkout", "actions/setup-node"), false)
+}
+
+///|
+test "glob star matches single segment" {
+  assert_eq(glob_match("actions/*", "actions/checkout"), true)
+  assert_eq(glob_match("actions/*", "actions/setup-node"), true)
+}
+
+///|
+test "glob star case-insensitive" {
+  assert_eq(glob_match("Actions/*", "actions/checkout"), true)
+  assert_eq(glob_match("actions/*", "Actions/Checkout"), true)
+}
+
+///|
+test "glob star does not match slash" {
+  assert_eq(glob_match("actions/*", "actions/checkout/extra"), false)
+}
+
+///|
+test "glob star does not match different owner" {
+  assert_eq(glob_match("actions/*", "github/codeql-action"), false)
+}
+
+///|
+test "glob doublestar matches anything" {
+  assert_eq(glob_match("actions/**", "actions/checkout"), true)
+  assert_eq(glob_match("actions/**", "actions/checkout/extra"), true)
+  assert_eq(glob_match("org/**", "org/repo"), true)
+}
+
+///|
+test "glob doublestar case-insensitive" {
+  assert_eq(glob_match("Actions/**", "actions/checkout"), true)
+}
+
+///|
+test "glob star-star matches any owner/repo" {
+  assert_eq(glob_match("*/*", "actions/checkout"), true)
+  assert_eq(glob_match("*/*", "org/repo"), true)
+}
+
+///|
+test "glob no match returns false" {
+  assert_eq(glob_match("org/*", "actions/checkout"), false)
+}
+
+///|
+test "glob empty pattern" {
+  assert_eq(glob_match("", "actions/checkout"), false)
+  assert_eq(glob_match("", ""), true)
+}

--- a/core/config/moon.pkg
+++ b/core/config/moon.pkg
@@ -1,0 +1,4 @@
+import {
+  "maruloop/papion",
+  "moonbitlang/core/json",
+}

--- a/core/config/pkg.generated.mbti
+++ b/core/config/pkg.generated.mbti
@@ -8,6 +8,8 @@ import {
 // Values
 pub fn glob_match(String, String) -> Bool
 
+pub fn glob_match_lowered(String, String) -> Bool
+
 pub fn matches_allowed(@papion.Policy, @papion.ActionRef) -> Bool
 
 pub fn matches_disallowed(@papion.Policy, @papion.ActionRef) -> Bool

--- a/core/config/pkg.generated.mbti
+++ b/core/config/pkg.generated.mbti
@@ -1,0 +1,24 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "maruloop/papion/config"
+
+import {
+  "maruloop/papion",
+}
+
+// Values
+pub fn glob_match(String, String) -> Bool
+
+pub fn matches_allowed(@papion.Policy, @papion.ActionRef) -> Bool
+
+pub fn matches_disallowed(@papion.Policy, @papion.ActionRef) -> Bool
+
+pub fn parse_policy(String) -> Result[@papion.Policy, String]
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+


### PR DESCRIPTION
## Summary

- Adds `core/config` package implementing policy configuration parsing and action matching
- `parse_policy(json_str)` — parses policy JSON (host converts TOML→JSON) into `Policy`; missing fields use defaults (`sha_pinning=true`, empty lists)
- `glob_match(pattern, text)` — case-insensitive glob matching with `*` (single segment) and `**` (any)
- `matches_allowed(policy, action_ref)` — empty list = pass-all; otherwise pattern-matches `owner/repo`
- `matches_disallowed(policy, action_ref)` — true if any disallowed pattern matches
- 54 tests, all passing

Closes #5

## Test plan

- [ ] All 54 unit tests pass (`moon test`)
- [ ] Builds for both targets (`moon build --target wasm-gc`, `--target js`)
- [ ] Format clean (`moon fmt --check`)
- [ ] `.mbti` interface in sync (`moon info && git diff --exit-code`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)