### PR TITLE
NO-ISSUE WS4: Add core/rules package

### DIFF
--- a/core/README.mbt.md
+++ b/core/README.mbt.md
@@ -8,8 +8,8 @@ Pure MoonBit engine for scanning GitHub Actions. No I/O, no host imports — all
 |---------|---------|
 | `papion` (root) | Core data types shared by all packages |
 | `papion/parser` | Parse action.yml JSON into core types |
-| `papion/config` | Parse policy configuration JSON, glob matching for allowed/disallowed lists (**this PR**) |
-| `papion/rules` | Evaluate policy rules against action references (planned: WS4) |
+| `papion/config` | Parse policy configuration JSON, glob matching for allowed/disallowed lists |
+| `papion/rules` | Evaluate policy rules against action references (**this PR**) |
 | `papion/format` | Format scan results as human-readable or JSON output (planned: WS7) |
 | `papion/engine` | Orchestrate a full scan (WASM entry point) (planned: WS5) |
 

--- a/core/rules/moon.pkg
+++ b/core/rules/moon.pkg
@@ -1,0 +1,4 @@
+import {
+  "maruloop/papion",
+  "maruloop/papion/config",
+}

--- a/core/rules/pkg.generated.mbti
+++ b/core/rules/pkg.generated.mbti
@@ -1,0 +1,26 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "maruloop/papion/rules"
+
+import {
+  "maruloop/papion",
+}
+
+// Values
+pub fn check_allowed(@papion.ActionRef, @papion.Policy) -> Array[@papion.Finding]
+
+pub fn check_disallowed(@papion.ActionRef, @papion.Policy) -> Array[@papion.Finding]
+
+pub fn check_sha_pinning(@papion.ActionRef, @papion.Policy) -> Array[@papion.Finding]
+
+pub fn classify_ref(String) -> @papion.RefKind
+
+pub fn evaluate(@papion.ActionRef, @papion.Policy) -> Array[@papion.Finding]
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+

--- a/core/rules/rules.mbt
+++ b/core/rules/rules.mbt
@@ -11,7 +11,7 @@ fn format_target(action_ref : @papion.ActionRef) -> String {
 ///|
 /// Classify a git ref by its format.
 ///
-/// Returns `Sha` if the ref is exactly 40 lowercase hex characters.
+/// Returns `Sha` if the ref is exactly 40 hex characters (case-insensitive).
 /// Returns `Branch` for everything else — the pure core cannot distinguish
 /// tags from branches without API access, so the stricter classification is used.
 pub fn classify_ref(git_ref : String) -> @papion.RefKind {
@@ -20,7 +20,7 @@ pub fn classify_ref(git_ref : String) -> @papion.RefKind {
   }
   for ch in git_ref.iter() {
     match ch {
-      '0'..='9' | 'a'..='f' => ()
+      '0'..='9' | 'a'..='f' | 'A'..='F' => ()
       _ => return Branch
     }
   }
@@ -31,8 +31,8 @@ pub fn classify_ref(git_ref : String) -> @papion.RefKind {
 /// Check the SHA-pinning rule against an action reference.
 ///
 /// Produces a Fail finding when sha_pinning is enabled and the ref is not a
-/// 40-character lowercase hex SHA. Returns an empty array when the rule is
-/// disabled or the ref is already pinned.
+/// 40-character hex SHA (case-insensitive). Returns an empty array when the
+/// rule is disabled or the ref is already pinned.
 pub fn check_sha_pinning(
   action_ref : @papion.ActionRef,
   policy : @papion.Policy,
@@ -49,7 +49,7 @@ pub fn check_sha_pinning(
       rule: "sha-pinning",
       target: format_target(action_ref),
       context: None,
-      message: "action ref is not pinned to a SHA — use a 40-character lowercase hex commit SHA instead of a tag or branch name",
+      message: "action ref is not pinned to a SHA — use a 40-character hex commit SHA instead of a tag or branch name",
       suggestion: None,
     },
   ]
@@ -60,6 +60,7 @@ pub fn check_sha_pinning(
 ///
 /// Produces a Fail finding when the allowed list is non-empty and the action
 /// does not match any pattern. An empty allowed list passes all actions.
+/// Patterns in policy.allowed must be pre-normalized to lowercase (use parse_policy).
 pub fn check_allowed(
   action_ref : @papion.ActionRef,
   policy : @papion.Policy,
@@ -83,6 +84,7 @@ pub fn check_allowed(
 /// Check the disallowed-list rule against an action reference.
 ///
 /// Produces a Fail finding when the action matches any disallowed pattern.
+/// Patterns in policy.disallowed must be pre-normalized to lowercase (use parse_policy).
 pub fn check_disallowed(
   action_ref : @papion.ActionRef,
   policy : @papion.Policy,

--- a/core/rules/rules.mbt
+++ b/core/rules/rules.mbt
@@ -1,0 +1,114 @@
+///|
+fn format_target(action_ref : @papion.ActionRef) -> String {
+  action_ref.owner + "/" + action_ref.repo + "@" + action_ref.git_ref
+}
+
+///|
+/// Classify a git ref by its format.
+///
+/// Returns `Sha` if the ref is exactly 40 lowercase hex characters.
+/// Returns `Branch` for everything else — the pure core cannot distinguish
+/// tags from branches without API access, so the stricter classification is used.
+pub fn classify_ref(git_ref : String) -> @papion.RefKind {
+  if git_ref.length() != 40 {
+    return Branch
+  }
+  for ch in git_ref.iter() {
+    match ch {
+      '0'..='9' | 'a'..='f' => ()
+      _ => return Branch
+    }
+  }
+  Sha
+}
+
+///|
+/// Check the SHA-pinning rule against an action reference.
+///
+/// Produces a Fail finding when sha_pinning is enabled and the ref is not a
+/// 40-character lowercase hex SHA. Returns an empty array when the rule is
+/// disabled or the ref is already pinned.
+pub fn check_sha_pinning(
+  action_ref : @papion.ActionRef,
+  policy : @papion.Policy,
+) -> Array[@papion.Finding] {
+  if !policy.sha_pinning {
+    return []
+  }
+  if classify_ref(action_ref.git_ref) == Sha {
+    return []
+  }
+  [
+    {
+      level: Fail,
+      rule: "sha-pinning",
+      target: format_target(action_ref),
+      context: None,
+      message: "action ref is not pinned to a SHA — use a 40-character commit SHA instead of a tag or branch name",
+      suggestion: None,
+    },
+  ]
+}
+
+///|
+/// Check the allowed-list rule against an action reference.
+///
+/// Produces a Fail finding when the allowed list is non-empty and the action
+/// does not match any pattern. An empty allowed list passes all actions.
+pub fn check_allowed(
+  action_ref : @papion.ActionRef,
+  policy : @papion.Policy,
+) -> Array[@papion.Finding] {
+  if @config.matches_allowed(policy, action_ref) {
+    return []
+  }
+  [
+    {
+      level: Fail,
+      rule: "allowed-list",
+      target: format_target(action_ref),
+      context: None,
+      message: "action is not in the allowed list",
+      suggestion: None,
+    },
+  ]
+}
+
+///|
+/// Check the disallowed-list rule against an action reference.
+///
+/// Produces a Fail finding when the action matches any disallowed pattern.
+pub fn check_disallowed(
+  action_ref : @papion.ActionRef,
+  policy : @papion.Policy,
+) -> Array[@papion.Finding] {
+  if !@config.matches_disallowed(policy, action_ref) {
+    return []
+  }
+  [
+    {
+      level: Fail,
+      rule: "disallowed-list",
+      target: format_target(action_ref),
+      context: None,
+      message: "action matches a disallowed pattern",
+      suggestion: None,
+    },
+  ]
+}
+
+///|
+/// Apply all policy rules to an action reference and collect findings.
+///
+/// Rules run in order: sha-pinning, allowed-list, disallowed-list.
+/// All findings are collected — rules are independent.
+pub fn evaluate(
+  action_ref : @papion.ActionRef,
+  policy : @papion.Policy,
+) -> Array[@papion.Finding] {
+  let findings : Array[@papion.Finding] = []
+  findings.append(check_sha_pinning(action_ref, policy))
+  findings.append(check_allowed(action_ref, policy))
+  findings.append(check_disallowed(action_ref, policy))
+  findings
+}

--- a/core/rules/rules.mbt
+++ b/core/rules/rules.mbt
@@ -1,6 +1,11 @@
 ///|
 fn format_target(action_ref : @papion.ActionRef) -> String {
-  action_ref.owner + "/" + action_ref.repo + "@" + action_ref.git_ref
+  let base = action_ref.owner + "/" + action_ref.repo
+  let with_path = match action_ref.path {
+    Some(p) => base + "/" + p
+    None => base
+  }
+  with_path + "@" + action_ref.git_ref
 }
 
 ///|
@@ -44,7 +49,7 @@ pub fn check_sha_pinning(
       rule: "sha-pinning",
       target: format_target(action_ref),
       context: None,
-      message: "action ref is not pinned to a SHA — use a 40-character commit SHA instead of a tag or branch name",
+      message: "action ref is not pinned to a SHA — use a 40-character lowercase hex commit SHA instead of a tag or branch name",
       suggestion: None,
     },
   ]

--- a/core/rules/rules_test.mbt
+++ b/core/rules/rules_test.mbt
@@ -5,9 +5,15 @@ test "classify_ref 40-char lowercase hex is Sha" {
 }
 
 ///|
-test "classify_ref 40-char uppercase hex is Branch" {
+test "classify_ref 40-char uppercase hex is Sha" {
   let sha = "A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2"
-  assert_eq(classify_ref(sha), @papion.RefKind::Branch)
+  assert_eq(classify_ref(sha), @papion.RefKind::Sha)
+}
+
+///|
+test "classify_ref 40-char mixed-case hex is Sha" {
+  let sha = "a1B2c3D4e5F6a1B2c3D4e5F6a1B2c3D4e5F6a1B2"
+  assert_eq(classify_ref(sha), @papion.RefKind::Sha)
 }
 
 ///|

--- a/core/rules/rules_test.mbt
+++ b/core/rules/rules_test.mbt
@@ -233,6 +233,42 @@ test "evaluate action in both allowed and disallowed produces disallowed finding
 }
 
 ///|
+test "check_sha_pinning with path includes path in target" {
+  let action_ref : @papion.ActionRef = {
+    owner: "myorg",
+    repo: "actions",
+    git_ref: "v2",
+    path: Some("deploy"),
+  }
+  let policy = @papion.Policy::default()
+  let findings = check_sha_pinning(action_ref, policy)
+  assert_eq(findings.length(), 1)
+  assert_eq(findings[0].target, "myorg/actions/deploy@v2")
+}
+
+///|
+test "evaluate with path includes path in finding target" {
+  let action_ref : @papion.ActionRef = {
+    owner: "myorg",
+    repo: "actions",
+    git_ref: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+    path: Some("sub"),
+  }
+  let policy : @papion.Policy = {
+    sha_pinning: true,
+    allowed: ["github/*"],
+    disallowed: [],
+  }
+  let findings = evaluate(action_ref, policy)
+  assert_eq(findings.length(), 1)
+  assert_eq(findings[0].rule, "allowed-list")
+  assert_eq(
+    findings[0].target,
+    "myorg/actions/sub@a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+  )
+}
+
+///|
 test "evaluate all passing produces no findings" {
   let action_ref : @papion.ActionRef = {
     owner: "actions",

--- a/core/rules/rules_test.mbt
+++ b/core/rules/rules_test.mbt
@@ -1,0 +1,249 @@
+///|
+test "classify_ref 40-char lowercase hex is Sha" {
+  let sha = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+  assert_eq(classify_ref(sha), @papion.RefKind::Sha)
+}
+
+///|
+test "classify_ref 40-char uppercase hex is Branch" {
+  let sha = "A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2"
+  assert_eq(classify_ref(sha), @papion.RefKind::Branch)
+}
+
+///|
+test "classify_ref tag-like ref is Branch" {
+  assert_eq(classify_ref("v4"), @papion.RefKind::Branch)
+}
+
+///|
+test "classify_ref branch-like ref is Branch" {
+  assert_eq(classify_ref("main"), @papion.RefKind::Branch)
+}
+
+///|
+test "classify_ref 39-char hex is Branch" {
+  let short = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b"
+  assert_eq(classify_ref(short), @papion.RefKind::Branch)
+}
+
+///|
+test "classify_ref 41-char hex is Branch" {
+  let long = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b20"
+  assert_eq(classify_ref(long), @papion.RefKind::Branch)
+}
+
+///|
+test "classify_ref empty string is Branch" {
+  assert_eq(classify_ref(""), @papion.RefKind::Branch)
+}
+
+///|
+test "check_sha_pinning SHA ref passes" {
+  let action_ref : @papion.ActionRef = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+    path: None,
+  }
+  let policy = @papion.Policy::default()
+  assert_eq(check_sha_pinning(action_ref, policy), [])
+}
+
+///|
+test "check_sha_pinning non-SHA ref fails" {
+  let action_ref : @papion.ActionRef = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "v4",
+    path: None,
+  }
+  let policy = @papion.Policy::default()
+  let findings = check_sha_pinning(action_ref, policy)
+  assert_eq(findings.length(), 1)
+  assert_eq(findings[0].level, @papion.FindingLevel::Fail)
+  assert_eq(findings[0].rule, "sha-pinning")
+  assert_eq(findings[0].target, "actions/checkout@v4")
+}
+
+///|
+test "check_sha_pinning disabled skips" {
+  let action_ref : @papion.ActionRef = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "v4",
+    path: None,
+  }
+  let policy : @papion.Policy = {
+    sha_pinning: false,
+    allowed: [],
+    disallowed: [],
+  }
+  assert_eq(check_sha_pinning(action_ref, policy), [])
+}
+
+///|
+test "check_allowed empty list passes all" {
+  let action_ref : @papion.ActionRef = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "v4",
+    path: None,
+  }
+  let policy : @papion.Policy = {
+    sha_pinning: true,
+    allowed: [],
+    disallowed: [],
+  }
+  assert_eq(check_allowed(action_ref, policy), [])
+}
+
+///|
+test "check_allowed matching pattern passes" {
+  let action_ref : @papion.ActionRef = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "v4",
+    path: None,
+  }
+  let policy : @papion.Policy = {
+    sha_pinning: true,
+    allowed: ["actions/*"],
+    disallowed: [],
+  }
+  assert_eq(check_allowed(action_ref, policy), [])
+}
+
+///|
+test "check_allowed no match fails" {
+  let action_ref : @papion.ActionRef = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "v4",
+    path: None,
+  }
+  let policy : @papion.Policy = {
+    sha_pinning: true,
+    allowed: ["github/*"],
+    disallowed: [],
+  }
+  let findings = check_allowed(action_ref, policy)
+  assert_eq(findings.length(), 1)
+  assert_eq(findings[0].level, @papion.FindingLevel::Fail)
+  assert_eq(findings[0].rule, "allowed-list")
+  assert_eq(findings[0].target, "actions/checkout@v4")
+}
+
+///|
+test "check_disallowed matching pattern fails" {
+  let action_ref : @papion.ActionRef = {
+    owner: "bad-org",
+    repo: "evil-action",
+    git_ref: "v1",
+    path: None,
+  }
+  let policy : @papion.Policy = {
+    sha_pinning: true,
+    allowed: [],
+    disallowed: ["bad-org/*"],
+  }
+  let findings = check_disallowed(action_ref, policy)
+  assert_eq(findings.length(), 1)
+  assert_eq(findings[0].level, @papion.FindingLevel::Fail)
+  assert_eq(findings[0].rule, "disallowed-list")
+  assert_eq(findings[0].target, "bad-org/evil-action@v1")
+}
+
+///|
+test "check_disallowed no match passes" {
+  let action_ref : @papion.ActionRef = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "v4",
+    path: None,
+  }
+  let policy : @papion.Policy = {
+    sha_pinning: true,
+    allowed: [],
+    disallowed: ["bad-org/*"],
+  }
+  assert_eq(check_disallowed(action_ref, policy), [])
+}
+
+///|
+test "evaluate SHA ref empty policy produces no findings" {
+  let action_ref : @papion.ActionRef = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+    path: None,
+  }
+  let policy = @papion.Policy::default()
+  assert_eq(evaluate(action_ref, policy), [])
+}
+
+///|
+test "evaluate non-SHA ref default policy produces sha-pinning finding" {
+  let action_ref : @papion.ActionRef = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "v4",
+    path: None,
+  }
+  let policy = @papion.Policy::default()
+  let findings = evaluate(action_ref, policy)
+  assert_eq(findings.length(), 1)
+  assert_eq(findings[0].rule, "sha-pinning")
+}
+
+///|
+test "evaluate non-SHA ref not in allowed list produces two findings" {
+  let action_ref : @papion.ActionRef = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "v4",
+    path: None,
+  }
+  let policy : @papion.Policy = {
+    sha_pinning: true,
+    allowed: ["github/*"],
+    disallowed: [],
+  }
+  let findings = evaluate(action_ref, policy)
+  assert_eq(findings.length(), 2)
+  assert_eq(findings[0].rule, "sha-pinning")
+  assert_eq(findings[1].rule, "allowed-list")
+}
+
+///|
+test "evaluate action in both allowed and disallowed produces disallowed finding" {
+  let action_ref : @papion.ActionRef = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+    path: None,
+  }
+  let policy : @papion.Policy = {
+    sha_pinning: true,
+    allowed: ["actions/*"],
+    disallowed: ["actions/*"],
+  }
+  let findings = evaluate(action_ref, policy)
+  assert_eq(findings.length(), 1)
+  assert_eq(findings[0].rule, "disallowed-list")
+}
+
+///|
+test "evaluate all passing produces no findings" {
+  let action_ref : @papion.ActionRef = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+    path: None,
+  }
+  let policy : @papion.Policy = {
+    sha_pinning: true,
+    allowed: ["actions/*"],
+    disallowed: ["bad-org/*"],
+  }
+  assert_eq(evaluate(action_ref, policy), [])
+}

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -297,13 +297,18 @@ Strict separation
 
 ### Decision
 
-Prefer **Pure Core (no host import)** initially
+Prefer **Pure Core (no host import)** for v1
 
 ### Rationale
 
 * Simplifies multi-runtime support
 * Improves safety
 * Reduces complexity
+* Host pre-resolves any API-dependent data (e.g. `RefKind` via `GET /repos/{owner}/{repo}/git/ref/tags/{ref}` and `.../heads/{ref}`) and passes it into core via data structures
+
+### Future consideration (pre-v2)
+
+If YAML fetching moves into core via a `fetch_yaml` host import, a `resolve_ref_kind` import becomes a natural and low-cost addition. In that model the host shrinks to a thin shell — WASM runtime + import function implementations only. This is a compelling architecture for v2's Cloudflare Worker target where minimising host-side logic reduces deployment surface. The async constraint (WASM imports are synchronous by default) must be resolved first, either via Asyncify or JSPI.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `core/rules` package implementing the three built-in policy rules
- `classify_ref(git_ref)` — classifies a ref: 40-char lowercase hex → `Sha`, everything else → `Branch` (strictest: core cannot distinguish tags from branches without API access)
- `check_sha_pinning(action_ref, policy)` — `Fail` when ref is not SHA-pinned and `sha_pinning` is enabled
- `check_allowed(action_ref, policy)` — `Fail` when action is not in a non-empty allowed list (empty list = pass-all)
- `check_disallowed(action_ref, policy)` — `Fail` when action matches any disallowed pattern
- `evaluate(action_ref, policy)` — composite runner applying all three rules in order; findings are independent and concatenated
- 20 tests, all passing; reuses `matches_allowed`/`matches_disallowed` from `core/config`

Closes #6

## Test plan

- [x] All 86 unit tests pass (`moon test`)
- [x] Builds for both targets (`moon build --target wasm-gc`, `--target js`)
- [x] Format clean (`moon fmt --check`)
- [x] `.mbti` interface in sync (`moon info && git diff --exit-code`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)