### PR TITLE
WS2 refactor: Parse action.yml YAML directly in core

### DIFF
--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: hustcer/setup-moonbit@e9b0a3082767ae669bf7588992ae3ba9eac09baa
+      - run: moon update
       - run: moon fmt --check
       - run: moon test
       - run: moon build --target wasm-gc

--- a/core/moon.mod.json
+++ b/core/moon.mod.json
@@ -1,6 +1,9 @@
 {
   "name": "maruloop/papion",
   "version": "0.1.0",
+  "deps": {
+    "moonbit-community/yaml": "0.0.4"
+  },
   "readme": "README.mbt.md",
   "repository": "",
   "license": "MIT",

--- a/core/parser/moon.pkg
+++ b/core/parser/moon.pkg
@@ -1,4 +1,4 @@
 import {
   "maruloop/papion",
-  "moonbitlang/core/json",
+  "moonbit-community/yaml",
 }

--- a/core/parser/parser.mbt
+++ b/core/parser/parser.mbt
@@ -40,36 +40,60 @@ pub fn parse_action_ref(uses : String) -> Result[@papion.ActionRef, String] {
 }
 
 ///|
-/// Parse action.yml content (as JSON string) into an ActionYml.
-///
-/// The host must convert YAML to JSON before passing to this function.
-/// The JSON must preserve the original action.yml field names (e.g. `using`).
-pub fn parse_action_yml(json_str : String) -> Result[@papion.ActionYml, String] {
-  try {
-    let json = @json.parse(json_str)
-    action_yml_from_json(json)
-  } catch {
-    e => Err(e.to_string())
+/// Parse action.yml content (as YAML string) into an ActionYml.
+pub fn parse_action_yml(yaml_str : String) -> Result[@papion.ActionYml, String] {
+  let docs = @yaml.Yaml::load_from_string(yaml_str) catch {
+    e => return Err(e.to_string())
+  }
+  match docs.length() {
+    0 => return Err("empty YAML document")
+    1 => ()
+    _ => return Err("expected exactly one YAML document in action.yml")
+  }
+  action_yml_from_yaml(docs[0])
+}
+
+///|
+// Coerce any YAML scalar to String. Boolean and Integer use MoonBit's
+// canonical repr ("true"/"false", decimal) because the yaml library does
+// not preserve the original source text for those variants (unlike Real,
+// which carries repr~). This library follows YAML 1.2 semantics: bare
+// "on"/"yes"/etc. remain strings, only "true"/"false" parse as booleans.
+// Boolean coercion is therefore rare in practice but handled for safety.
+fn yaml_scalar_to_string(yaml : @yaml.Yaml) -> String? {
+  match yaml {
+    String(s) => Some(s)
+    Integer(n) => Some(n.to_string())
+    Boolean(b) => Some(if b { "true" } else { "false" })
+    Real(_, repr~) => Some(repr)
+    _ => None
   }
 }
 
 ///|
-fn action_yml_from_json(json : Json) -> Result[@papion.ActionYml, String] {
-  guard json is Object(obj) else {
-    return Err("expected JSON object for ActionYml")
+fn action_yml_from_yaml(yaml : @yaml.Yaml) -> Result[@papion.ActionYml, String] {
+  guard yaml is Map(obj) else {
+    return Err("expected YAML mapping for ActionYml")
   }
   let name = match obj.get("name") {
-    Some(String(s)) => s
-    _ => return Err("missing or invalid 'name' field")
+    Some(v) =>
+      match yaml_scalar_to_string(v) {
+        Some(s) => s
+        None => return Err("missing or invalid 'name' field")
+      }
+    None => return Err("missing or invalid 'name' field")
   }
   let description = match obj.get("description") {
-    Some(String(s)) => Some(s)
-    Some(_) => return Err("invalid 'description' field: expected string")
-    None => None
+    Some(Null) | None => None
+    Some(v) =>
+      match yaml_scalar_to_string(v) {
+        Some(s) => Some(s)
+        None => return Err("invalid 'description' field: expected string")
+      }
   }
   let runs = match obj.get("runs") {
-    Some(runs_json) =>
-      match runs_from_json(runs_json) {
+    Some(runs_yaml) =>
+      match runs_from_yaml(runs_yaml) {
         Ok(r) => r
         Err(e) => return Err(e)
       }
@@ -79,18 +103,22 @@ fn action_yml_from_json(json : Json) -> Result[@papion.ActionYml, String] {
 }
 
 ///|
-fn runs_from_json(json : Json) -> Result[@papion.Runs, String] {
-  guard json is Object(obj) else { return Err("expected JSON object for runs") }
+fn runs_from_yaml(yaml : @yaml.Yaml) -> Result[@papion.Runs, String] {
+  guard yaml is Map(obj) else { return Err("expected YAML mapping for runs") }
   let runner = match obj.get("using") {
-    Some(String(s)) => s
-    _ => return Err("missing or invalid 'using' field in runs")
+    Some(v) =>
+      match yaml_scalar_to_string(v) {
+        Some(s) => s
+        None => return Err("missing or invalid 'using' field in runs")
+      }
+    None => return Err("missing or invalid 'using' field in runs")
   }
   let steps = match obj.get("steps") {
     None => None
     Some(Array(arr)) => {
       let acc : Array[@papion.CompositeStep] = Array::new()
-      for step_json in arr {
-        match composite_step_from_json(step_json) {
+      for step_yaml in arr {
+        match composite_step_from_yaml(step_yaml) {
           Ok(step) => acc.push(step)
           Err(e) => return Err(e)
         }
@@ -103,31 +131,35 @@ fn runs_from_json(json : Json) -> Result[@papion.Runs, String] {
 }
 
 ///|
-fn optional_string_field(
-  obj : Map[String, Json],
+fn optional_yaml_string(
+  obj : Map[String, @yaml.Yaml],
   field : String,
 ) -> Result[String?, String] {
   match obj.get(field) {
     None => Ok(None)
-    Some(String(s)) => Ok(Some(s))
-    Some(_) => Err("invalid '" + field + "' field in step: expected string")
+    Some(Null) => Err("invalid '" + field + "' field in step: expected string")
+    Some(v) =>
+      match yaml_scalar_to_string(v) {
+        Some(s) => Ok(Some(s))
+        None => Err("invalid '" + field + "' field in step: expected string")
+      }
   }
 }
 
 ///|
-fn composite_step_from_json(
-  json : Json,
+fn composite_step_from_yaml(
+  yaml : @yaml.Yaml,
 ) -> Result[@papion.CompositeStep, String] {
-  guard json is Object(obj) else { return Err("expected JSON object for step") }
-  let uses = match optional_string_field(obj, "uses") {
+  guard yaml is Map(obj) else { return Err("expected YAML mapping for step") }
+  let uses = match optional_yaml_string(obj, "uses") {
     Ok(v) => v
     Err(e) => return Err(e)
   }
-  let run = match optional_string_field(obj, "run") {
+  let run = match optional_yaml_string(obj, "run") {
     Ok(v) => v
     Err(e) => return Err(e)
   }
-  let name = match optional_string_field(obj, "name") {
+  let name = match optional_yaml_string(obj, "name") {
     Ok(v) => v
     Err(e) => return Err(e)
   }

--- a/core/parser/parser_test.mbt
+++ b/core/parser/parser_test.mbt
@@ -92,9 +92,11 @@ test "parse_action_ref error empty path" {
 
 ///|
 test "parse_action_yml minimal node action" {
-  let json_str =
-    #|{"name":"Setup Node","runs":{"using":"node20"}}
-  let result = parse_action_yml(json_str)
+  let yaml_str =
+    #|name: Setup Node
+    #|runs:
+    #|  using: node20
+  let result = parse_action_yml(yaml_str)
   assert_eq(
     result,
     Ok({
@@ -107,9 +109,16 @@ test "parse_action_yml minimal node action" {
 
 ///|
 test "parse_action_yml composite action with steps" {
-  let json_str =
-    #|{"name":"My Action","description":"does things","runs":{"using":"composite","steps":[{"uses":"actions/checkout@v4","name":"checkout"},{"run":"echo hello"}]}}
-  let result = parse_action_yml(json_str)
+  let yaml_str =
+    #|name: My Action
+    #|description: does things
+    #|runs:
+    #|  using: composite
+    #|  steps:
+    #|    - uses: actions/checkout@v4
+    #|      name: checkout
+    #|    - run: echo hello
+  let result = parse_action_yml(yaml_str)
   assert_eq(
     result,
     Ok({
@@ -131,36 +140,104 @@ test "parse_action_yml composite action with steps" {
 }
 
 ///|
-test "parse_action_yml malformed JSON" {
-  let result = parse_action_yml("not json at all")
+test "parse_action_yml malformed YAML" {
+  let result = parse_action_yml(":\t bad yaml\t:\n\t")
   match result {
     Err(_) => ()
-    Ok(_) => fail("expected Err for malformed JSON")
+    Ok(_) => fail("expected Err for malformed YAML")
   }
 }
 
 ///|
+test "parse_action_yml multi-document YAML rejected" {
+  let yaml_str =
+    #|name: My Action
+    #|runs:
+    #|  using: node20
+    #|---
+    #|name: Second Document
+    #|runs:
+    #|  using: node20
+  let result = parse_action_yml(yaml_str)
+  assert_eq(result, Err("expected exactly one YAML document in action.yml"))
+}
+
+///|
 test "parse_action_yml invalid description type" {
-  let json_str =
-    #|{"name":"My Action","description":123,"runs":{"using":"node20"}}
-  let result = parse_action_yml(json_str)
+  let yaml_str =
+    #|name: My Action
+    #|description:
+    #|  nested: map
+    #|runs:
+    #|  using: node20
+  let result = parse_action_yml(yaml_str)
   assert_eq(result, Err("invalid 'description' field: expected string"))
 }
 
 ///|
 test "parse_action_yml invalid steps type" {
-  let json_str =
-    #|{"name":"My Action","runs":{"using":"composite","steps":"bad"}}
-  let result = parse_action_yml(json_str)
+  let yaml_str =
+    #|name: My Action
+    #|runs:
+    #|  using: composite
+    #|  steps: bad
+  let result = parse_action_yml(yaml_str)
   assert_eq(result, Err("invalid 'steps' field: expected array"))
 }
 
 ///|
-test "parse_action_yml invalid uses type in step" {
-  let json_str =
-    #|{"name":"My Action","runs":{"using":"composite","steps":[{"uses":42}]}}
-  let result = parse_action_yml(json_str)
+test "parse_action_yml null uses in step rejected" {
+  let yaml_str =
+    #|name: My Action
+    #|runs:
+    #|  using: composite
+    #|  steps:
+    #|    - uses: ~
+  let result = parse_action_yml(yaml_str)
   assert_eq(result, Err("invalid 'uses' field in step: expected string"))
+}
+
+///|
+test "parse_action_yml invalid uses type in step" {
+  let yaml_str =
+    #|name: My Action
+    #|runs:
+    #|  using: composite
+    #|  steps:
+    #|    - uses:
+    #|        nested: object
+  let result = parse_action_yml(yaml_str)
+  assert_eq(result, Err("invalid 'uses' field in step: expected string"))
+}
+
+///|
+test "parse_action_yml yaml boolean name coercion" {
+  // The yaml library follows YAML 1.2: only "true"/"false" are booleans.
+  // Bare "on" is parsed as a string, so it passes through unchanged.
+  // Explicit true is parsed as Boolean(true) and coerced to "true".
+  let yaml_str =
+    #|name: true
+    #|runs:
+    #|  using: node20
+  let result = parse_action_yml(yaml_str)
+  match result {
+    Ok(yml) => assert_eq(yml.name, "true")
+    Err(e) => fail("expected Ok but got Err: \{e}")
+  }
+}
+
+///|
+test "parse_action_yml yaml integer description coercion" {
+  let yaml_str =
+    #|name: My Action
+    #|description: 42
+    #|runs:
+    #|  using: node20
+  let result = parse_action_yml(yaml_str)
+  match result {
+    Ok(yml) => assert_eq(yml.description, Some("42"))
+    Err(e) => fail("expected Ok but got Err: \{e}")
+  }
 }
 
 ///|


### PR DESCRIPTION
## Summary

- Adds `moonbit-community/yaml` v0.0.4 dependency to core
- Refactors `parse_action_yml` to accept raw YAML strings instead of pre-converted JSON
- Removes host-side YAML→JSON conversion requirement
- Updates all parser tests to use YAML input

## Motivation

Per ADR Decision 17: keeping YAML parsing in the core makes the logic portable across CLI, browser, and Cloudflare Worker runtimes. Eliminates the need for a YAML library in the Go host (WS6).

## Test plan

- [x] `moon test` — 88 tests pass
- [x] `moon info && moon fmt` — interface and formatting clean

Tracking: #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)