### PR TITLE
NO-ISSUE WS5: Add core/engine — scan orchestrator

### DIFF
--- a/core/engine/README.mbt.md
+++ b/core/engine/README.mbt.md
@@ -1,0 +1,37 @@
+# core/engine
+
+Scan orchestrator. Wires parser, config, and rules into a single entry point.
+
+## API
+
+```mbt nocheck
+pub fn scan(
+  target : @papion.ScanTarget,
+  action_yml_yaml : String,
+  config_json : String,
+) -> Result[@papion.ScanResult, String]
+```
+
+- `target` — the action being scanned (`owner`, `repo`, `git_ref`)
+- `action_yml_yaml` — raw YAML content of `action.yml`
+- `config_json` — papion policy as JSON (empty string uses defaults)
+
+Returns `Ok(ScanResult)` with findings and summary, or `Err(message)` if the YAML or config is unparseable.
+
+## Behaviour
+
+1. Parse `action_yml_yaml` with `@parser.parse_action_yml`
+2. Parse `config_json` with `@config.parse_policy` (empty string → default policy)
+3. Extract action refs from composite steps with `@parser.extract_refs`
+4. Evaluate each ref against the policy with `@rules.evaluate`
+5. Count failures and warnings for the summary
+6. Return `ScanResult { target, findings, summary }`
+
+Non-composite actions (e.g. `using: node20`) produce zero findings from ref extraction but still apply rules to zero refs, so the result is always a valid `ScanResult`.
+
+## Error handling
+
+- Invalid YAML → `Err("...")`
+- Invalid config JSON → `Err("...")`
+- Empty action_yml_yaml → `Err("empty YAML document")`
+- Empty config_json → uses default policy (sha_pinning=true, no allowed/disallowed lists)

--- a/core/engine/engine.mbt
+++ b/core/engine/engine.mbt
@@ -1,0 +1,29 @@
+///|
+/// Scan an action against a policy.
+///
+/// Parses action_yml_yaml (raw YAML) and config_json (JSON policy, empty = defaults),
+/// extracts all action refs from composite steps, evaluates each ref against the
+/// policy, and returns a ScanResult with aggregated findings and summary counts.
+pub fn scan(
+  target : @papion.ScanTarget,
+  action_yml_yaml : String,
+  config_json : String,
+) -> Result[@papion.ScanResult, String] {
+  let yml = match @parser.parse_action_yml(action_yml_yaml) {
+    Ok(y) => y
+    Err(e) => return Err(e)
+  }
+  let effective_config = if config_json.is_empty() { "{}" } else { config_json }
+  let policy = match @config.parse_policy(effective_config) {
+    Ok(p) => p
+    Err(e) => return Err(e)
+  }
+  let refs = @parser.extract_refs(yml)
+  let findings : Array[@papion.Finding] = []
+  for ref_ in refs {
+    findings.append(@rules.evaluate(ref_, policy))
+  }
+  let failures = findings.iter().filter(fn(f) { f.level == Fail }).count()
+  let warnings = findings.iter().filter(fn(f) { f.level == Warn }).count()
+  Ok({ target, findings, summary: { failures, warnings } })
+}

--- a/core/engine/engine_test.mbt
+++ b/core/engine/engine_test.mbt
@@ -1,0 +1,199 @@
+///|
+test "scan unpinned ref produces sha-pinning failure" {
+  let target : @papion.ScanTarget = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "v4",
+  }
+  let yaml_str =
+    #|name: My Action
+    #|runs:
+    #|  using: composite
+    #|  steps:
+    #|    - uses: actions/checkout@v4
+  let result = scan(target, yaml_str, "")
+  match result {
+    Err(e) => fail("unexpected error: \{e}")
+    Ok(r) => {
+      assert_eq(r.summary.failures, 1)
+      assert_eq(r.summary.warnings, 0)
+      assert_eq(r.findings.length(), 1)
+      assert_eq(r.findings[0].rule, "sha-pinning")
+    }
+  }
+}
+
+///|
+test "scan pinned ref produces zero findings" {
+  let target : @papion.ScanTarget = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "11bd71901bbe5b1630ceea73d27597364c9af683",
+  }
+  let yaml_str =
+    #|name: My Action
+    #|runs:
+    #|  using: composite
+    #|  steps:
+    #|    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+  let result = scan(target, yaml_str, "")
+  match result {
+    Err(e) => fail("unexpected error: \{e}")
+    Ok(r) => {
+      assert_eq(r.summary.failures, 0)
+      assert_eq(r.summary.warnings, 0)
+      assert_eq(r.findings, [])
+    }
+  }
+}
+
+///|
+test "scan disallowed action produces failure" {
+  let target : @papion.ScanTarget = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "v4",
+  }
+  let yaml_str =
+    #|name: My Action
+    #|runs:
+    #|  using: composite
+    #|  steps:
+    #|    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+  let config_json =
+    #|{"sha_pinning":true,"allowed":[],"disallowed":["actions/checkout"]}
+  let result = scan(target, yaml_str, config_json)
+  match result {
+    Err(e) => fail("unexpected error: \{e}")
+    Ok(r) => {
+      assert_eq(r.summary.failures, 1)
+      assert_eq(r.findings[0].rule, "disallowed-list")
+    }
+  }
+}
+
+///|
+test "scan allowed list restricts to listed actions" {
+  let target : @papion.ScanTarget = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "v4",
+  }
+  let yaml_str =
+    #|name: My Action
+    #|runs:
+    #|  using: composite
+    #|  steps:
+    #|    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+    #|    - uses: third-party/action@11bd71901bbe5b1630ceea73d27597364c9af683
+  let config_json =
+    #|{"sha_pinning":true,"allowed":["actions/*"],"disallowed":[]}
+  let result = scan(target, yaml_str, config_json)
+  match result {
+    Err(e) => fail("unexpected error: \{e}")
+    Ok(r) => {
+      assert_eq(r.summary.failures, 1)
+      assert_eq(r.findings[0].rule, "allowed-list")
+      assert_eq(
+        r.findings[0].target,
+        "third-party/action@11bd71901bbe5b1630ceea73d27597364c9af683",
+      )
+    }
+  }
+}
+
+///|
+test "scan node action produces zero findings" {
+  let target : @papion.ScanTarget = {
+    owner: "actions",
+    repo: "setup-node",
+    git_ref: "v4",
+  }
+  let yaml_str =
+    #|name: Setup Node
+    #|runs:
+    #|  using: node20
+  let result = scan(target, yaml_str, "")
+  match result {
+    Err(e) => fail("unexpected error: \{e}")
+    Ok(r) => {
+      assert_eq(r.summary.failures, 0)
+      assert_eq(r.summary.warnings, 0)
+      assert_eq(r.findings, [])
+    }
+  }
+}
+
+///|
+test "scan multiple unpinned refs aggregates findings" {
+  let target : @papion.ScanTarget = {
+    owner: "my-org",
+    repo: "my-action",
+    git_ref: "main",
+  }
+  let yaml_str =
+    #|name: Multi Step
+    #|runs:
+    #|  using: composite
+    #|  steps:
+    #|    - uses: actions/checkout@v4
+    #|    - uses: actions/setup-node@v4
+  let result = scan(target, yaml_str, "")
+  match result {
+    Err(e) => fail("unexpected error: \{e}")
+    Ok(r) => {
+      assert_eq(r.summary.failures, 2)
+      assert_eq(r.findings.length(), 2)
+    }
+  }
+}
+
+///|
+test "scan invalid YAML returns error" {
+  let target : @papion.ScanTarget = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "v4",
+  }
+  let result = scan(target, ":\t bad\t:\n\t", "")
+  match result {
+    Err(_) => ()
+    Ok(_) => fail("expected error for invalid YAML")
+  }
+}
+
+///|
+test "scan invalid config JSON returns error" {
+  let target : @papion.ScanTarget = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "v4",
+  }
+  let yaml_str =
+    #|name: My Action
+    #|runs:
+    #|  using: node20
+  let result = scan(target, yaml_str, "not json")
+  match result {
+    Err(_) => ()
+    Ok(_) => fail("expected error for invalid config JSON")
+  }
+}
+
+///|
+test "scan result target matches input" {
+  let target : @papion.ScanTarget = {
+    owner: "my-org",
+    repo: "my-action",
+    git_ref: "abc123",
+  }
+  let yaml_str =
+    #|name: My Action
+    #|runs:
+    #|  using: node20
+  let result = scan(target, yaml_str, "")
+  match result {
+    Err(e) => fail("unexpected error: \{e}")
+    Ok(r) => assert_eq(r.target, target)
+  }
+}

--- a/core/engine/moon.pkg
+++ b/core/engine/moon.pkg
@@ -1,0 +1,6 @@
+import {
+  "maruloop/papion",
+  "maruloop/papion/parser",
+  "maruloop/papion/config",
+  "maruloop/papion/rules",
+}

--- a/core/engine/pkg.generated.mbti
+++ b/core/engine/pkg.generated.mbti
@@ -1,0 +1,18 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "maruloop/papion/engine"
+
+import {
+  "maruloop/papion",
+}
+
+// Values
+pub fn scan(@papion.ScanTarget, String, String) -> Result[@papion.ScanResult, String]
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+


### PR DESCRIPTION
## Summary

- Implements `scan(target, action_yml_yaml, config_json) -> Result[ScanResult, String]`
- Wires `@parser.parse_action_yml` → `@parser.extract_refs` → `@rules.evaluate` → aggregate
- Empty `config_json` uses default policy (sha_pinning=true, no lists)
- 8 integration tests covering: unpinned refs, pinned refs, disallowed, allowed list, node actions, multiple findings, error cases

## Notes

- Depends on #16 (parser YAML refactor) — rebased on top of `ws2/core-parser-yaml`
- WASM export deferred to WS8 per plan

## Test plan

- [x] `moon test` — 97 tests pass (all packages)
- [x] `moon info && moon fmt` — clean

Closes #7
Tracking: #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)