### PR TITLE
NO-ISSUE WS7: Add core/format — output formatting

### DIFF
--- a/core/format/README.mbt.md
+++ b/core/format/README.mbt.md
@@ -1,0 +1,62 @@
+# core/format
+
+Output formatters for scan results. Produces human-readable or JSON output from a `ScanResult`.
+
+## API
+
+```mbt nocheck
+pub fn format_human(result : @papion.ScanResult) -> String
+pub fn format_json(result : @papion.ScanResult) -> String
+```
+
+## Human format
+
+```
+  WARN  actions/checkout@v4
+        Referenced by tag, not pinned to a SHA.
+        Tip: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+  FAIL  actions/github-script@v7 (used in composite step "setup")
+        Not pinned to a SHA.
+
+2 findings  (1 failure, 1 warning)
+```
+
+Rules:
+- Each finding starts with 2-space indent, level label (`WARN` or `FAIL`), 2 spaces, then the target
+- If the finding has a `context`, append ` (context)` to the target line
+- Message on the next line, indented 8 spaces
+- If the finding has a `suggestion`, add `Tip: suggestion` on the line after the message (8-space indent)
+- Blank line between findings
+- Summary line at the end: `N findings  (F failure(s), W warning(s))`
+  - Use singular "finding"/"failure"/"warning" when the corresponding count is 1 (e.g. `1 finding  (1 failure, 0 warnings)`)
+- Zero findings: `No findings`
+
+## JSON format
+
+```json
+{
+  "target": "owner/repo@ref",
+  "ref": "ref",
+  "findings": [
+    {
+      "level": "warn",
+      "rule": "sha-pinning",
+      "target": "owner/repo@ref",
+      "context": "composite step \"setup\"",
+      "message": "...",
+      "suggestion": "..."
+    }
+  ],
+  "summary": {
+    "failures": 1,
+    "warnings": 1
+  }
+}
+```
+
+Rules:
+- `target` is `"owner/repo@ref"` string (not a nested object)
+- `ref` is the `git_ref` from `ScanTarget`
+- `level` values are lowercase: `"warn"` or `"fail"`
+- Omit `context` and `suggestion` fields from findings when absent (`None`)

--- a/core/format/format.mbt
+++ b/core/format/format.mbt
@@ -1,0 +1,118 @@
+///|
+fn target_string(t : @papion.ScanTarget) -> String {
+  t.owner + "/" + t.repo + "@" + t.git_ref
+}
+
+///|
+fn level_label(level : @papion.FindingLevel) -> String {
+  match level {
+    Warn => "WARN"
+    Fail => "FAIL"
+  }
+}
+
+///|
+fn level_lower(level : @papion.FindingLevel) -> String {
+  match level {
+    Warn => "warn"
+    Fail => "fail"
+  }
+}
+
+///|
+fn plural(n : Int, singular : String, plural_form : String) -> String {
+  if n == 1 {
+    singular
+  } else {
+    plural_form
+  }
+}
+
+///|
+/// Format a ScanResult as human-readable text.
+///
+/// Each finding shows WARN/FAIL label, target (with optional context), message,
+/// and optional suggestion. Findings separated by blank lines.
+/// Summary line uses singular/plural: "N finding/findings  (F failure/failures, W warning/warnings)".
+/// Zero findings produces "No findings".
+pub fn format_human(result : @papion.ScanResult) -> String {
+  if result.findings.is_empty() {
+    return "No findings"
+  }
+  let buf = StringBuilder::new()
+  let mut first = true
+  for finding in result.findings {
+    if !first {
+      buf.write_string("\n\n")
+    }
+    first = false
+    let target_line = if finding.context is Some(ctx) {
+      finding.target + " (" + ctx + ")"
+    } else {
+      finding.target
+    }
+    buf.write_string("  ")
+    buf.write_string(level_label(finding.level))
+    buf.write_string("  ")
+    buf.write_string(target_line)
+    buf.write_string("\n        ")
+    buf.write_string(finding.message)
+    if finding.suggestion is Some(s) {
+      buf.write_string("\n        Tip: ")
+      buf.write_string(s)
+    }
+  }
+  let f = result.summary.failures
+  let w = result.summary.warnings
+  let n = result.findings.length()
+  buf.write_string("\n\n")
+  buf.write_string(n.to_string())
+  buf.write_string(" ")
+  buf.write_string(plural(n, "finding", "findings"))
+  buf.write_string("  (")
+  buf.write_string(f.to_string())
+  buf.write_string(" ")
+  buf.write_string(plural(f, "failure", "failures"))
+  buf.write_string(", ")
+  buf.write_string(w.to_string())
+  buf.write_string(" ")
+  buf.write_string(plural(w, "warning", "warnings"))
+  buf.write_string(")")
+  buf.to_string()
+}
+
+///|
+fn finding_to_json(f : @papion.Finding) -> Json {
+  let obj : Map[String, Json] = {
+    "level": Json::string(level_lower(f.level)),
+    "rule": Json::string(f.rule),
+    "target": Json::string(f.target),
+    "message": Json::string(f.message),
+  }
+  if f.context is Some(ctx) {
+    obj["context"] = Json::string(ctx)
+  }
+  if f.suggestion is Some(s) {
+    obj["suggestion"] = Json::string(s)
+  }
+  Json::object(obj)
+}
+
+///|
+/// Format a ScanResult as JSON.
+///
+/// Target is serialized as "owner/repo@ref" string.
+/// Level values are lowercase ("warn"/"fail").
+/// Optional finding fields (context, suggestion) are omitted when absent.
+pub fn format_json(result : @papion.ScanResult) -> String {
+  let root : Map[String, Json] = {
+    "target": Json::string(target_string(result.target)),
+    "ref": Json::string(result.target.git_ref),
+    "findings": Json::array(result.findings.map(finding_to_json)),
+    "summary": Json::object({
+      "failures": Json::number(result.summary.failures.to_double()),
+      "warnings": Json::number(result.summary.warnings.to_double()),
+    }),
+  }
+  Json::object(root).stringify()
+}

--- a/core/format/format_test.mbt
+++ b/core/format/format_test.mbt
@@ -1,0 +1,300 @@
+///|
+fn make_target(
+  owner : String,
+  repo : String,
+  git_ref : String,
+) -> @papion.ScanTarget {
+  { owner, repo, git_ref }
+}
+
+///|
+fn warn_finding(target : String, message : String) -> @papion.Finding {
+  {
+    level: Warn,
+    rule: "sha-pinning",
+    target,
+    context: None,
+    message,
+    suggestion: None,
+  }
+}
+
+///|
+fn fail_finding(target : String, message : String) -> @papion.Finding {
+  {
+    level: Fail,
+    rule: "sha-pinning",
+    target,
+    context: None,
+    message,
+    suggestion: None,
+  }
+}
+
+///|
+test "format_human zero findings" {
+  let result : @papion.ScanResult = {
+    target: make_target("actions", "checkout", "v4"),
+    findings: [],
+    summary: { failures: 0, warnings: 0 },
+  }
+  assert_eq(format_human(result), "No findings")
+}
+
+///|
+test "format_human single warning" {
+  let result : @papion.ScanResult = {
+    target: make_target("actions", "checkout", "v4"),
+    findings: [
+      warn_finding("actions/checkout@v4", "action ref is not pinned to a SHA"),
+    ],
+    summary: { failures: 0, warnings: 1 },
+  }
+  let output = format_human(result)
+  assert_eq(
+    output, "  WARN  actions/checkout@v4\n        action ref is not pinned to a SHA\n\n1 finding  (0 failures, 1 warning)",
+  )
+}
+
+///|
+test "format_human single failure" {
+  let result : @papion.ScanResult = {
+    target: make_target("actions", "checkout", "v4"),
+    findings: [
+      fail_finding("actions/checkout@v4", "action is not in the allowed list"),
+    ],
+    summary: { failures: 1, warnings: 0 },
+  }
+  let output = format_human(result)
+  assert_eq(
+    output, "  FAIL  actions/checkout@v4\n        action is not in the allowed list\n\n1 finding  (1 failure, 0 warnings)",
+  )
+}
+
+///|
+test "format_human with context" {
+  let finding : @papion.Finding = {
+    level: Fail,
+    rule: "sha-pinning",
+    target: "actions/github-script@v7",
+    context: Some("composite step \"setup\""),
+    message: "Not pinned to a SHA.",
+    suggestion: None,
+  }
+  let result : @papion.ScanResult = {
+    target: make_target("my-org", "my-action", "main"),
+    findings: [finding],
+    summary: { failures: 1, warnings: 0 },
+  }
+  let output = format_human(result)
+  assert_eq(
+    output, "  FAIL  actions/github-script@v7 (composite step \"setup\")\n        Not pinned to a SHA.\n\n1 finding  (1 failure, 0 warnings)",
+  )
+}
+
+///|
+test "format_human with suggestion" {
+  let finding : @papion.Finding = {
+    level: Warn,
+    rule: "sha-pinning",
+    target: "actions/checkout@v4",
+    context: None,
+    message: "Referenced by tag, not pinned to a SHA.",
+    suggestion: Some(
+      "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683",
+    ),
+  }
+  let result : @papion.ScanResult = {
+    target: make_target("actions", "checkout", "v4"),
+    findings: [finding],
+    summary: { failures: 0, warnings: 1 },
+  }
+  let output = format_human(result)
+  assert_eq(
+    output, "  WARN  actions/checkout@v4\n        Referenced by tag, not pinned to a SHA.\n        Tip: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683\n\n1 finding  (0 failures, 1 warning)",
+  )
+}
+
+///|
+test "format_human multiple findings" {
+  let result : @papion.ScanResult = {
+    target: make_target("my-org", "my-action", "main"),
+    findings: [
+      warn_finding(
+        "actions/checkout@v4", "Referenced by tag, not pinned to a SHA.",
+      ),
+      fail_finding("actions/github-script@v7", "Not pinned to a SHA."),
+    ],
+    summary: { failures: 1, warnings: 1 },
+  }
+  let output = format_human(result)
+  assert_eq(
+    output, "  WARN  actions/checkout@v4\n        Referenced by tag, not pinned to a SHA.\n\n  FAIL  actions/github-script@v7\n        Not pinned to a SHA.\n\n2 findings  (1 failure, 1 warning)",
+  )
+}
+
+///|
+test "format_human plural failures and warnings" {
+  let result : @papion.ScanResult = {
+    target: make_target("my-org", "my-action", "main"),
+    findings: [
+      fail_finding("actions/checkout@v4", "msg1"),
+      fail_finding("actions/setup-node@v4", "msg2"),
+      warn_finding("actions/cache@v3", "msg3"),
+      warn_finding("actions/upload-artifact@v3", "msg4"),
+    ],
+    summary: { failures: 2, warnings: 2 },
+  }
+  let output = format_human(result)
+  assert_true(output.has_suffix("4 findings  (2 failures, 2 warnings)"))
+}
+
+///|
+fn get_str(json : Json, key : String) -> String? {
+  match json {
+    Object(obj) =>
+      match obj.get(key) {
+        Some(String(s)) => Some(s)
+        _ => None
+      }
+    _ => None
+  }
+}
+
+///|
+fn get_num(json : Json, key : String) -> Double? {
+  match json {
+    Object(obj) =>
+      match obj.get(key) {
+        Some(Number(n, ..)) => Some(n)
+        _ => None
+      }
+    _ => None
+  }
+}
+
+///|
+test "format_json zero findings" {
+  let result : @papion.ScanResult = {
+    target: make_target("actions", "checkout", "v4"),
+    findings: [],
+    summary: { failures: 0, warnings: 0 },
+  }
+  let output = format_json(result)
+  let parsed = @json.parse(output)
+  assert_eq(get_str(parsed, "target"), Some("actions/checkout@v4"))
+  assert_eq(get_str(parsed, "ref"), Some("v4"))
+  match parsed {
+    Object(obj) =>
+      match obj.get("findings") {
+        Some(Array(arr)) => assert_eq(arr.length(), 0)
+        _ => fail("expected findings array")
+      }
+    _ => fail("expected JSON object")
+  }
+  match parsed {
+    Object(obj) =>
+      match obj.get("summary") {
+        Some(s) => {
+          assert_eq(get_num(s, "failures"), Some(0.0))
+          assert_eq(get_num(s, "warnings"), Some(0.0))
+        }
+        _ => fail("expected summary")
+      }
+    _ => fail("expected JSON object")
+  }
+}
+
+///|
+test "format_json finding with all fields" {
+  let finding : @papion.Finding = {
+    level: Warn,
+    rule: "sha-pinning",
+    target: "actions/checkout@v4",
+    context: Some("step context"),
+    message: "not pinned",
+    suggestion: Some("pin to sha"),
+  }
+  let result : @papion.ScanResult = {
+    target: make_target("actions", "checkout", "v4"),
+    findings: [finding],
+    summary: { failures: 0, warnings: 1 },
+  }
+  let output = format_json(result)
+  let parsed = @json.parse(output)
+  match parsed {
+    Object(obj) =>
+      match obj.get("findings") {
+        Some(Array(arr)) => {
+          assert_eq(arr.length(), 1)
+          assert_eq(get_str(arr[0], "level"), Some("warn"))
+          assert_eq(get_str(arr[0], "rule"), Some("sha-pinning"))
+          assert_eq(get_str(arr[0], "target"), Some("actions/checkout@v4"))
+          assert_eq(get_str(arr[0], "context"), Some("step context"))
+          assert_eq(get_str(arr[0], "message"), Some("not pinned"))
+          assert_eq(get_str(arr[0], "suggestion"), Some("pin to sha"))
+        }
+        _ => fail("expected findings array")
+      }
+    _ => fail("expected JSON object")
+  }
+}
+
+///|
+test "format_json finding omits absent optional fields" {
+  let finding : @papion.Finding = {
+    level: Fail,
+    rule: "allowed-list",
+    target: "third-party/action@v1",
+    context: None,
+    message: "not in allowed list",
+    suggestion: None,
+  }
+  let result : @papion.ScanResult = {
+    target: make_target("actions", "checkout", "v4"),
+    findings: [finding],
+    summary: { failures: 1, warnings: 0 },
+  }
+  let output = format_json(result)
+  let parsed = @json.parse(output)
+  match parsed {
+    Object(obj) =>
+      match obj.get("findings") {
+        Some(Array(arr)) =>
+          match arr[0] {
+            Object(finding_obj) => {
+              assert_eq(get_str(arr[0], "level"), Some("fail"))
+              assert_eq(finding_obj.get("context"), None)
+              assert_eq(finding_obj.get("suggestion"), None)
+            }
+            _ => fail("expected finding object")
+          }
+        _ => fail("expected findings array")
+      }
+    _ => fail("expected JSON object")
+  }
+}
+
+///|
+test "format_json output is valid JSON" {
+  let result : @papion.ScanResult = {
+    target: make_target(
+      "my-org", "my-action", "abc123def456abc123def456abc123def456abc1",
+    ),
+    findings: [
+      {
+        level: Fail,
+        rule: "sha-pinning",
+        target: "actions/checkout@v4",
+        context: Some("checkout step"),
+        message: "not pinned",
+        suggestion: None,
+      },
+    ],
+    summary: { failures: 1, warnings: 0 },
+  }
+  let output = format_json(result)
+  // Parsing should not throw
+  let _ = @json.parse(output)
+  assert_true(true)
+}

--- a/core/format/moon.pkg
+++ b/core/format/moon.pkg
@@ -1,0 +1,4 @@
+import {
+  "maruloop/papion",
+  "moonbitlang/core/json",
+}

--- a/core/format/pkg.generated.mbti
+++ b/core/format/pkg.generated.mbti
@@ -1,0 +1,20 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "maruloop/papion/format"
+
+import {
+  "maruloop/papion",
+}
+
+// Values
+pub fn format_human(@papion.ScanResult) -> String
+
+pub fn format_json(@papion.ScanResult) -> String
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits
+


### PR DESCRIPTION
## Summary

- Implements `format_human(ScanResult) -> String` and `format_json(ScanResult) -> String`
- Human format: `WARN`/`FAIL` labels, optional context in parens, message, `Tip:` suggestion, summary line with correct pluralization
- JSON format: target as `"owner/repo@ref"` string, `ref` field, lowercase level values, optional fields omitted when absent
- 11 tests covering: zero findings, single warning/failure, context, suggestion, multiple findings, pluralization, JSON structure, omitted fields

## Test plan

- [x] `moon test` — 100 tests pass (all packages)
- [x] `moon info && moon fmt` — clean

Closes #9
Tracking: #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)