### PR TITLE
NO-ISSUE fix(readme): align JSON/human examples with actual formatter output

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ papion run actions/checkout@v4
 
   WARN  actions/checkout@v4
         Referenced by tag, not pinned to a SHA.
-        Tip: use actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        Tip: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
   FAIL  actions/github-script@v7 (used in composite step "setup")
         Not pinned to a SHA.
@@ -111,6 +111,7 @@ papion run actions/checkout@v4 --format json
     {
       "level": "warn",
       "rule": "sha-pinning",
+      "target": "actions/checkout@v4",
       "message": "Referenced by tag, not pinned to a SHA.",
       "suggestion": "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
     },


### PR DESCRIPTION
## Summary

- Remove spurious `"use "` from `Tip:` example — matches actual `format_human` output
- Add `"target"` field to first finding in JSON example — `target` is always present on a `Finding`

Fixes divergence flagged in the PR #18 review thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)