### PR TITLE
WS6: Add Go host layer (cli/)

### DIFF
--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -1,0 +1,22 @@
+name: CLI Tests
+
+on:
+  push:
+    branches: [main]
+    paths: ['cli/**', '.github/workflows/cli-test.yml']
+  pull_request:
+    paths: ['cli/**', '.github/workflows/cli-test.yml']
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: cli
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
+        with:
+          go-version-file: cli/go.mod
+      - run: go vet ./...
+      - run: go test ./...

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ papion run actions/checkout@v4
 
   WARN  actions/checkout@v4
         Referenced by tag, not pinned to a SHA.
-        Tip: use actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        Tip: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
   FAIL  actions/github-script@v7 (used in composite step "setup")
         Not pinned to a SHA.
@@ -111,6 +111,7 @@ papion run actions/checkout@v4 --format json
     {
       "level": "warn",
       "rule": "sha-pinning",
+      "target": "actions/checkout@v4",
       "message": "Referenced by tag, not pinned to a SHA.",
       "suggestion": "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"
     },

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,93 @@
+# Papion CLI Host Layer
+
+`cli/` is the Go host for the Papion MoonBit core. The host is responsible for I/O, process wiring, and the user-facing command line. The core remains responsible for parsing policy and action content, evaluating rules, and formatting findings.
+
+## Responsibilities
+
+Host layer responsibilities:
+
+- Parse `papion run org/repo@ref`
+- Resolve configuration from `--config`, `.github/papion.toml`, or `papion.toml`
+- Convert TOML policy input into JSON for the core
+- Download action source archives from the GitHub tarball API
+- Extract `action.yml` or `action.yaml` from the archive
+- Marshal request data into JSON strings for the WASM boundary
+- Select human or JSON output mode
+- Return the correct process exit code
+
+Core responsibilities:
+
+- Parse `action.yml`
+- Parse policy JSON
+- Evaluate rules
+- Build `ScanResult`
+- Format findings as human or JSON output
+
+## Package Layout
+
+- `main.go`: process entry point
+- `cmd/`: Cobra commands and CLI orchestration
+- `github/`: GitHub archive download client and archive extraction
+- `config/`: config lookup and TOML-to-JSON conversion
+- `wasm/`: Go mirror types, scanner interface, stub scanner, and wazero skeleton
+
+## Request Flow
+
+1. Parse `owner/repo@ref`
+2. Load TOML config and convert it to JSON
+3. Download the repository tarball from GitHub
+4. Extract `action.yml` or `action.yaml`
+5. Call the scanner with:
+   - target as JSON-serializable Go structs
+   - raw YAML content
+   - policy JSON
+6. Format the result for stdout
+7. Compute the exit code from `--fail-on`
+
+## Interfaces
+
+`github.Client` abstracts archive download:
+
+```go
+type Client interface {
+    DownloadArchive(ctx context.Context, owner, repo, ref string) ([]byte, error)
+}
+```
+
+`wasm.Scanner` abstracts the MoonBit core:
+
+```go
+type Scanner interface {
+    Scan(target ScanTarget, yamlContent string, policyJSON string) (*ScanResult, error)
+    FormatHuman(result *ScanResult) (string, error)
+    FormatJSON(result *ScanResult) (string, error)
+    Close(ctx context.Context) error
+}
+```
+
+## WASM Boundary Contract
+
+The MoonBit core exports a string-based contract:
+
+- `scan(ScanTarget, String, String) -> Result[ScanResult, String]`
+- `format_human(ScanResult) -> String`
+- `format_json(ScanResult) -> String`
+
+The Go host serializes structured data with `encoding/json` before crossing the boundary:
+
+- `ScanTarget` is serialized to JSON
+- policy TOML is converted into JSON and passed as a raw JSON string
+- `action.yml` is passed as raw YAML text
+- `ScanResult` is serialized/deserialized as JSON
+
+This keeps the host decoupled from MoonBit internals and makes the scanner interface easy to stub in tests.
+
+## Testing Strategy
+
+- `github/client_test.go`: HTTP behavior with `httptest.Server`
+- `github/archive_test.go`: tarball extraction behavior
+- `config/loader_test.go`: config lookup precedence and JSON conversion
+- `wasm/wazero_test.go`: type JSON round-trips and stub scanner behavior
+- `cmd/run_test.go`: CLI parsing, formatting, and exit code behavior with injected doubles
+
+The current milestone uses `StubScanner` in tests. Real wazero integration stays behind `WazeroScanner` and can be completed once the final WASM artifact is available.

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	gh "github.com/maruloop/papion/cli/github"
+	"github.com/maruloop/papion/cli/wasm"
+	"github.com/spf13/cobra"
+)
+
+type Dependencies struct {
+	Stdout           io.Writer
+	Stderr           io.Writer
+	Client           gh.Client
+	Scanner          wasm.Scanner
+	LoadConfig       func(configFlag string) (string, error)
+	ExtractActionYML func(data []byte) (string, error)
+}
+
+func Execute(ctx context.Context, args []string, deps Dependencies) (int, error) {
+	exitCode := 0
+	if deps.Stdout == nil {
+		deps.Stdout = io.Discard
+	}
+	if deps.Stderr == nil {
+		deps.Stderr = io.Discard
+	}
+	if deps.Scanner != nil {
+		defer func() {
+			_ = deps.Scanner.Close(ctx)
+		}()
+	}
+
+	rootCmd := NewRootCmd(deps, &exitCode)
+	rootCmd.SetArgs(args)
+	rootCmd.SetOut(deps.Stdout)
+	rootCmd.SetErr(deps.Stderr)
+	rootCmd.SetContext(ctx)
+
+	err := rootCmd.Execute()
+	if err != nil && exitCode == 0 {
+		exitCode = 2
+	}
+	return exitCode, err
+}
+
+func NewRootCmd(deps Dependencies, exitCode *int) *cobra.Command {
+	root := &cobra.Command{
+		Use:           "papion",
+		Short:         "Scan GitHub Actions for policy violations",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+	}
+	root.AddCommand(newRunCmd(deps, exitCode))
+	return root
+}
+
+func requireDeps(deps Dependencies) error {
+	switch {
+	case deps.Client == nil:
+		return fmt.Errorf("github client dependency is required")
+	case deps.Scanner == nil:
+		return fmt.Errorf("scanner dependency is required")
+	case deps.LoadConfig == nil:
+		return fmt.Errorf("config loader dependency is required")
+	case deps.ExtractActionYML == nil:
+		return fmt.Errorf("archive extractor dependency is required")
+	default:
+		return nil
+	}
+}

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -1,0 +1,132 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/maruloop/papion/cli/wasm"
+	"github.com/spf13/cobra"
+)
+
+func newRunCmd(deps Dependencies, exitCode *int) *cobra.Command {
+	var configPath string
+	var format string
+	var failOn string
+
+	cmd := &cobra.Command{
+		Use:   "run owner/repo@ref",
+		Short: "Scan a GitHub Action",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := requireDeps(deps); err != nil {
+				*exitCode = 2
+				return err
+			}
+
+			target, err := parseTarget(args[0])
+			if err != nil {
+				*exitCode = 2
+				return err
+			}
+
+			if format != "human" && format != "json" {
+				*exitCode = 2
+				return fmt.Errorf("invalid --format %q", format)
+			}
+			if failOn != "fail" && failOn != "warn" && failOn != "none" {
+				*exitCode = 2
+				return fmt.Errorf("invalid --fail-on %q", failOn)
+			}
+
+			policyJSON, err := deps.LoadConfig(configPath)
+			if err != nil {
+				*exitCode = 2
+				return err
+			}
+
+			archive, err := deps.Client.DownloadArchive(cmd.Context(), target.Owner, target.Repo, target.GitRef)
+			if err != nil {
+				*exitCode = 2
+				return err
+			}
+
+			yamlContent, err := deps.ExtractActionYML(archive)
+			if err != nil {
+				*exitCode = 2
+				return err
+			}
+
+			result, err := deps.Scanner.Scan(target, yamlContent, policyJSON)
+			if err != nil {
+				*exitCode = 2
+				return err
+			}
+
+			var output string
+			switch format {
+			case "json":
+				output, err = deps.Scanner.FormatJSON(result)
+			default:
+				output, err = deps.Scanner.FormatHuman(result)
+			}
+			if err != nil {
+				*exitCode = 2
+				return err
+			}
+
+			if _, err := fmt.Fprintln(deps.Stdout, output); err != nil {
+				*exitCode = 2
+				return err
+			}
+			*exitCode = findingsExitCode(result, failOn)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&configPath, "config", "", "Path to config file")
+	cmd.Flags().StringVarP(&format, "format", "f", "human", "Output format: human or json")
+	cmd.Flags().StringVarP(&failOn, "fail-on", "F", "fail", "Minimum level to exit 1: fail, warn, or none")
+
+	return cmd
+}
+
+func parseTarget(input string) (wasm.ScanTarget, error) {
+	at := strings.LastIndex(input, "@")
+	if at <= 0 || at == len(input)-1 {
+		return wasm.ScanTarget{}, fmt.Errorf("invalid target %q: expected owner/repo@ref", input)
+	}
+
+	repoPath := input[:at]
+	ref := input[at+1:]
+	parts := strings.Split(repoPath, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return wasm.ScanTarget{}, fmt.Errorf("invalid target %q: expected owner/repo@ref", input)
+	}
+
+	return wasm.ScanTarget{
+		Owner:  parts[0],
+		Repo:   parts[1],
+		GitRef: ref,
+	}, nil
+}
+
+func findingsExitCode(result *wasm.ScanResult, failOn string) int {
+	if result == nil {
+		return 0
+	}
+
+	switch failOn {
+	case "none":
+		return 0
+	case "warn":
+		if result.Summary.Failures > 0 || result.Summary.Warnings > 0 {
+			return 1
+		}
+	case "fail":
+		if result.Summary.Failures > 0 {
+			return 1
+		}
+	}
+
+	return 0
+}

--- a/cli/cmd/run_test.go
+++ b/cli/cmd/run_test.go
@@ -1,0 +1,176 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/maruloop/papion/cli/wasm"
+)
+
+type fakeClient struct {
+	archive []byte
+	err     error
+}
+
+func (f fakeClient) DownloadArchive(ctx context.Context, owner, repo, ref string) ([]byte, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.archive, nil
+}
+
+type fakeScanner struct {
+	result *wasm.ScanResult
+	err    error
+}
+
+func (f *fakeScanner) Scan(target wasm.ScanTarget, yamlContent string, policyJSON string) (*wasm.ScanResult, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.result, nil
+}
+
+func (f *fakeScanner) FormatHuman(result *wasm.ScanResult) (string, error) {
+	return "human output", nil
+}
+
+func (f *fakeScanner) FormatJSON(result *wasm.ScanResult) (string, error) {
+	return `{"ok":true}`, nil
+}
+
+func (f *fakeScanner) Close(ctx context.Context) error {
+	return nil
+}
+
+func sampleResult(levels ...wasm.FindingLevel) *wasm.ScanResult {
+	findings := make([]wasm.Finding, 0, len(levels))
+	summary := wasm.Summary{}
+	for i, level := range levels {
+		findings = append(findings, wasm.Finding{
+			Level:   level,
+			Rule:    "sha-pinning",
+			Target:  "actions/checkout@v4",
+			Message: "message",
+		})
+		if level == wasm.FindingLevelFail {
+			summary.Failures++
+		}
+		if level == wasm.FindingLevelWarn {
+			summary.Warnings++
+		}
+		_ = i
+	}
+	return &wasm.ScanResult{
+		Target:   wasm.ScanTarget{Owner: "actions", Repo: "checkout", GitRef: "v4"},
+		Findings: findings,
+		Summary:  summary,
+	}
+}
+
+func TestExecuteRun_DefaultsAndCleanExit(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	code, err := Execute(context.Background(), []string{"run", "actions/checkout@v4"}, Dependencies{
+		Stdout:           stdout,
+		Client:           fakeClient{archive: []byte("unused")},
+		Scanner:          &fakeScanner{result: sampleResult()},
+		LoadConfig:       func(flag string) (string, error) { return "", nil },
+		ExtractActionYML: func(data []byte) (string, error) { return "name: test", nil },
+	})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "human output" {
+		t.Fatalf("expected human output, got %q", got)
+	}
+}
+
+func TestExecuteRun_JSONOutput(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	code, err := Execute(context.Background(), []string{"run", "actions/checkout@v4", "--format", "json"}, Dependencies{
+		Stdout:           stdout,
+		Client:           fakeClient{archive: []byte("unused")},
+		Scanner:          &fakeScanner{result: sampleResult()},
+		LoadConfig:       func(flag string) (string, error) { return "", nil },
+		ExtractActionYML: func(data []byte) (string, error) { return "name: test", nil },
+	})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d", code)
+	}
+	if got := strings.TrimSpace(stdout.String()); got != `{"ok":true}` {
+		t.Fatalf("expected json output, got %q", got)
+	}
+}
+
+func TestExecuteRun_FailOnThresholds(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   []string
+		result *wasm.ScanResult
+		want   int
+	}{
+		{name: "fail threshold ignores warn", args: []string{"run", "actions/checkout@v4"}, result: sampleResult(wasm.FindingLevelWarn), want: 0},
+		{name: "fail threshold triggers on fail", args: []string{"run", "actions/checkout@v4"}, result: sampleResult(wasm.FindingLevelFail), want: 1},
+		{name: "warn threshold triggers on warn", args: []string{"run", "actions/checkout@v4", "--fail-on", "warn"}, result: sampleResult(wasm.FindingLevelWarn), want: 1},
+		{name: "none never fails", args: []string{"run", "actions/checkout@v4", "--fail-on", "none"}, result: sampleResult(wasm.FindingLevelFail, wasm.FindingLevelWarn), want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code, err := Execute(context.Background(), tt.args, Dependencies{
+				Stdout:           bytes.NewBuffer(nil),
+				Client:           fakeClient{archive: []byte("unused")},
+				Scanner:          &fakeScanner{result: tt.result},
+				LoadConfig:       func(flag string) (string, error) { return "", nil },
+				ExtractActionYML: func(data []byte) (string, error) { return "name: test", nil },
+			})
+			if err != nil {
+				t.Fatalf("Execute returned error: %v", err)
+			}
+			if code != tt.want {
+				t.Fatalf("expected exit code %d, got %d", tt.want, code)
+			}
+		})
+	}
+}
+
+func TestExecuteRun_InvalidTargetIsExitCode2(t *testing.T) {
+	code, err := Execute(context.Background(), []string{"run", "not-a-target"}, Dependencies{
+		Stdout:           bytes.NewBuffer(nil),
+		Client:           fakeClient{archive: []byte("unused")},
+		Scanner:          &fakeScanner{result: sampleResult()},
+		LoadConfig:       func(flag string) (string, error) { return "", nil },
+		ExtractActionYML: func(data []byte) (string, error) { return "name: test", nil },
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid target")
+	}
+	if code != 2 {
+		t.Fatalf("expected exit code 2, got %d", code)
+	}
+}
+
+func TestExecuteRun_ScanErrorIsExitCode2(t *testing.T) {
+	code, err := Execute(context.Background(), []string{"run", "actions/checkout@v4"}, Dependencies{
+		Stdout:           bytes.NewBuffer(nil),
+		Client:           fakeClient{archive: []byte("unused")},
+		Scanner:          &fakeScanner{err: errors.New("scan failed")},
+		LoadConfig:       func(flag string) (string, error) { return "", nil },
+		ExtractActionYML: func(data []byte) (string, error) { return "name: test", nil },
+	})
+	if err == nil {
+		t.Fatal("expected scanner error")
+	}
+	if code != 2 {
+		t.Fatalf("expected exit code 2, got %d", code)
+	}
+}

--- a/cli/config/loader.go
+++ b/cli/config/loader.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/BurntSushi/toml"
+)
+
+func LoadConfig(configFlag string) (string, error) {
+	path := configFlag
+	if path == "" {
+		for _, candidate := range []string{".github/papion.toml", "papion.toml"} {
+			if _, err := os.Stat(candidate); err == nil {
+				path = candidate
+				break
+			}
+		}
+	}
+
+	if path == "" {
+		return "", nil
+	}
+
+	var doc map[string]any
+	if _, err := toml.DecodeFile(path, &doc); err != nil {
+		return "", fmt.Errorf("decode config %s: %w", path, err)
+	}
+
+	data, err := json.Marshal(doc)
+	if err != nil {
+		return "", fmt.Errorf("marshal config %s to json: %w", path, err)
+	}
+
+	return string(data), nil
+}

--- a/cli/config/loader_test.go
+++ b/cli/config/loader_test.go
@@ -1,0 +1,106 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+}
+
+func decodeJSON(t *testing.T, s string) map[string]any {
+	t.Helper()
+	var out map[string]any
+	if err := json.Unmarshal([]byte(s), &out); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+	return out
+}
+
+func TestLoadConfig_ExplicitPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "custom.toml")
+	writeFile(t, path, "[policy]\nsha_pinning = true\n")
+
+	got, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig returned error: %v", err)
+	}
+	if decodeJSON(t, got)["policy"] == nil {
+		t.Fatalf("expected policy wrapper in %q", got)
+	}
+}
+
+func TestLoadConfig_FallbackGithubPath(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, ".github", "papion.toml"), "[policy]\nallowed = [\"actions/*\"]\n")
+
+	oldwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd failed: %v", err)
+	}
+	defer func() { _ = os.Chdir(oldwd) }()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("Chdir failed: %v", err)
+	}
+
+	got, err := LoadConfig("")
+	if err != nil {
+		t.Fatalf("LoadConfig returned error: %v", err)
+	}
+	if decodeJSON(t, got)["policy"] == nil {
+		t.Fatalf("expected policy wrapper in %q", got)
+	}
+}
+
+func TestLoadConfig_FallbackRepoRootPath(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "papion.toml"), "[policy]\ndisallowed = [\"bad/*\"]\n")
+
+	oldwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd failed: %v", err)
+	}
+	defer func() { _ = os.Chdir(oldwd) }()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("Chdir failed: %v", err)
+	}
+
+	got, err := LoadConfig("")
+	if err != nil {
+		t.Fatalf("LoadConfig returned error: %v", err)
+	}
+	if decodeJSON(t, got)["policy"] == nil {
+		t.Fatalf("expected policy wrapper in %q", got)
+	}
+}
+
+func TestLoadConfig_NoConfigFound(t *testing.T) {
+	dir := t.TempDir()
+
+	oldwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd failed: %v", err)
+	}
+	defer func() { _ = os.Chdir(oldwd) }()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("Chdir failed: %v", err)
+	}
+
+	got, err := LoadConfig("")
+	if err != nil {
+		t.Fatalf("LoadConfig returned error: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("expected empty config, got %q", got)
+	}
+}

--- a/cli/github/archive.go
+++ b/cli/github/archive.go
@@ -1,0 +1,45 @@
+package github
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"path"
+)
+
+func ExtractActionYml(tarballBytes []byte) (string, error) {
+	gzr, err := gzip.NewReader(bytes.NewReader(tarballBytes))
+	if err != nil {
+		return "", fmt.Errorf("open gzip archive: %w", err)
+	}
+	defer gzr.Close()
+
+	tr := tar.NewReader(gzr)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return "", fmt.Errorf("read tar archive: %w", err)
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+
+		base := path.Base(hdr.Name)
+		if base != "action.yml" && base != "action.yaml" {
+			continue
+		}
+
+		content, err := io.ReadAll(tr)
+		if err != nil {
+			return "", fmt.Errorf("read %s: %w", hdr.Name, err)
+		}
+		return string(content), nil
+	}
+
+	return "", fmt.Errorf("action.yml or action.yaml not found in archive")
+}

--- a/cli/github/archive_test.go
+++ b/cli/github/archive_test.go
@@ -1,0 +1,77 @@
+package github
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"strings"
+	"testing"
+)
+
+func buildTarball(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+
+	var raw bytes.Buffer
+	gz := gzip.NewWriter(&raw)
+	tw := tar.NewWriter(gz)
+	for name, content := range files {
+		hdr := &tar.Header{
+			Name: name,
+			Mode: 0o644,
+			Size: int64(len(content)),
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("WriteHeader failed: %v", err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatalf("Write failed: %v", err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar close failed: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gzip close failed: %v", err)
+	}
+
+	return raw.Bytes()
+}
+
+func TestExtractActionYml_FindsActionYml(t *testing.T) {
+	tarball := buildTarball(t, map[string]string{
+		"actions-checkout-sha/action.yml": "name: checkout\nruns:\n  using: composite\n",
+	})
+
+	got, err := ExtractActionYml(tarball)
+	if err != nil {
+		t.Fatalf("ExtractActionYml returned error: %v", err)
+	}
+	if !strings.Contains(got, "name: checkout") {
+		t.Fatalf("unexpected action content: %q", got)
+	}
+}
+
+func TestExtractActionYml_FindsActionYaml(t *testing.T) {
+	tarball := buildTarball(t, map[string]string{
+		"actions-checkout-sha/action.yaml": "name: checkout-yaml\n",
+	})
+
+	got, err := ExtractActionYml(tarball)
+	if err != nil {
+		t.Fatalf("ExtractActionYml returned error: %v", err)
+	}
+	if !strings.Contains(got, "checkout-yaml") {
+		t.Fatalf("unexpected action content: %q", got)
+	}
+}
+
+func TestExtractActionYml_MissingActionFile(t *testing.T) {
+	tarball := buildTarball(t, map[string]string{
+		"actions-checkout-sha/README.md": "no action here",
+	})
+
+	_, err := ExtractActionYml(tarball)
+	if err == nil || !strings.Contains(err.Error(), "action.yml") {
+		t.Fatalf("expected missing action.yml error, got %v", err)
+	}
+}

--- a/cli/github/client.go
+++ b/cli/github/client.go
@@ -1,0 +1,71 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+type Client interface {
+	DownloadArchive(ctx context.Context, owner, repo, ref string) ([]byte, error)
+}
+
+type HTTPClient struct {
+	BaseURL    string
+	HTTPClient *http.Client
+	Token      string
+}
+
+func NewHTTPClient(client *http.Client) *HTTPClient {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &HTTPClient{
+		BaseURL:    "https://api.github.com",
+		HTTPClient: client,
+		Token:      os.Getenv("GITHUB_TOKEN"),
+	}
+}
+
+func (c *HTTPClient) DownloadArchive(ctx context.Context, owner, repo, ref string) ([]byte, error) {
+	baseURL := c.BaseURL
+	if baseURL == "" {
+		baseURL = "https://api.github.com"
+	}
+	httpClient := c.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	url := fmt.Sprintf("%s/repos/%s/%s/tarball/%s", baseURL, owner, repo, ref)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	if c.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.Token)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("download archive: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read archive response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if resp.StatusCode == http.StatusForbidden {
+			return nil, fmt.Errorf("github api rate limit or access denied (status 403): %s", string(body))
+		}
+		return nil, fmt.Errorf("github api returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return body, nil
+}

--- a/cli/github/client_test.go
+++ b/cli/github/client_test.go
@@ -1,0 +1,85 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHTTPClientDownloadArchive_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Path; got != "/repos/actions/checkout/tarball/v4" {
+			t.Fatalf("unexpected path: %s", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Fatalf("unexpected auth header: %q", got)
+		}
+		_, _ = w.Write([]byte("archive"))
+	}))
+	defer server.Close()
+
+	client := &HTTPClient{
+		BaseURL:    server.URL,
+		HTTPClient: server.Client(),
+		Token:      "test-token",
+	}
+
+	body, err := client.DownloadArchive(context.Background(), "actions", "checkout", "v4")
+	if err != nil {
+		t.Fatalf("DownloadArchive returned error: %v", err)
+	}
+	if string(body) != "archive" {
+		t.Fatalf("unexpected body: %q", string(body))
+	}
+}
+
+func TestHTTPClientDownloadArchive_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "missing", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := &HTTPClient{
+		BaseURL:    server.URL,
+		HTTPClient: server.Client(),
+	}
+
+	_, err := client.DownloadArchive(context.Background(), "actions", "checkout", "v4")
+	if err == nil || !strings.Contains(err.Error(), "404") {
+		t.Fatalf("expected 404 error, got %v", err)
+	}
+}
+
+func TestHTTPClientDownloadArchive_RateLimited(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "rate limited", http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	client := &HTTPClient{
+		BaseURL:    server.URL,
+		HTTPClient: server.Client(),
+	}
+
+	_, err := client.DownloadArchive(context.Background(), "actions", "checkout", "v4")
+	if err == nil || !strings.Contains(strings.ToLower(err.Error()), "rate limit") {
+		t.Fatalf("expected rate limit error, got %v", err)
+	}
+}
+
+func TestHTTPClientDownloadArchive_NetworkError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	client := &HTTPClient{
+		BaseURL:    server.URL,
+		HTTPClient: &http.Client{Timeout: time.Second},
+	}
+	server.Close()
+
+	_, err := client.DownloadArchive(context.Background(), "actions", "checkout", "v4")
+	if err == nil {
+		t.Fatal("expected network error")
+	}
+}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,0 +1,14 @@
+module github.com/maruloop/papion/cli
+
+go 1.23.0
+
+require (
+	github.com/BurntSushi/toml v1.5.0
+	github.com/spf13/cobra v1.8.1
+	github.com/tetratelabs/wazero v1.8.2
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -1,0 +1,14 @@
+github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
+github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
+github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/tetratelabs/wazero v1.8.2 h1:yIgLR/b2bN31bjxwXHD8a3d+BogigR952csSDdLYEv4=
+github.com/tetratelabs/wazero v1.8.2/go.mod h1:yAI0XTsMBhREkM/YDAK/zNou3GoiAce1P6+rp/wQhjs=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/cli/main.go
+++ b/cli/main.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/maruloop/papion/cli/cmd"
+	"github.com/maruloop/papion/cli/config"
+	gh "github.com/maruloop/papion/cli/github"
+	"github.com/maruloop/papion/cli/wasm"
+)
+
+func main() {
+	code, err := cmd.Execute(context.Background(), os.Args[1:], cmd.Dependencies{
+		Stdout:           os.Stdout,
+		Stderr:           os.Stderr,
+		Client:           gh.NewHTTPClient(nil),
+		Scanner: &wasm.StubScanner{}, // TODO(WS8): replace with wasm.NewWazeroScanner() once core WASM artifact is available
+		LoadConfig:       config.LoadConfig,
+		ExtractActionYML: gh.ExtractActionYml,
+	})
+	if err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+	}
+	os.Exit(code)
+}

--- a/cli/testdata/fixtures/explicit.toml
+++ b/cli/testdata/fixtures/explicit.toml
@@ -1,0 +1,2 @@
+[policy]
+sha_pinning = true

--- a/cli/wasm/papion.wasm
+++ b/cli/wasm/papion.wasm
@@ -1,0 +1,1 @@
+placeholder

--- a/cli/wasm/scanner.go
+++ b/cli/wasm/scanner.go
@@ -1,0 +1,10 @@
+package wasm
+
+import "context"
+
+type Scanner interface {
+	Scan(target ScanTarget, yamlContent string, policyJSON string) (*ScanResult, error)
+	FormatHuman(result *ScanResult) (string, error)
+	FormatJSON(result *ScanResult) (string, error)
+	Close(ctx context.Context) error
+}

--- a/cli/wasm/stub.go
+++ b/cli/wasm/stub.go
@@ -1,0 +1,52 @@
+package wasm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+type StubScanner struct{}
+
+func (s *StubScanner) Scan(target ScanTarget, yamlContent string, policyJSON string) (*ScanResult, error) {
+	contextValue := "stub scanner"
+	suggestion := fmt.Sprintf("%s/%s@0000000000000000000000000000000000000000", target.Owner, target.Repo)
+	return &ScanResult{
+		Target: target,
+		Findings: []Finding{
+			{
+				Level:      FindingLevelWarn,
+				Rule:       "stub",
+				Target:     fmt.Sprintf("%s/%s@%s", target.Owner, target.Repo, target.GitRef),
+				Context:    &contextValue,
+				Message:    "Stub scanner result",
+				Suggestion: &suggestion,
+			},
+		},
+		Summary: Summary{
+			Warnings: 1,
+		},
+	}, nil
+}
+
+func (s *StubScanner) FormatHuman(result *ScanResult) (string, error) {
+	if result == nil {
+		return "", fmt.Errorf("result is nil")
+	}
+	return fmt.Sprintf("%d findings (%d failure, %d warning)", len(result.Findings), result.Summary.Failures, result.Summary.Warnings), nil
+}
+
+func (s *StubScanner) FormatJSON(result *ScanResult) (string, error) {
+	if result == nil {
+		return "", fmt.Errorf("result is nil")
+	}
+	data, err := json.Marshal(result)
+	if err != nil {
+		return "", fmt.Errorf("marshal result: %w", err)
+	}
+	return string(data), nil
+}
+
+func (s *StubScanner) Close(ctx context.Context) error {
+	return nil
+}

--- a/cli/wasm/types.go
+++ b/cli/wasm/types.go
@@ -1,0 +1,34 @@
+package wasm
+
+type ScanTarget struct {
+	Owner  string `json:"owner"`
+	Repo   string `json:"repo"`
+	GitRef string `json:"git_ref"`
+}
+
+type FindingLevel string
+
+const (
+	FindingLevelWarn FindingLevel = "Warn"
+	FindingLevelFail FindingLevel = "Fail"
+)
+
+type Finding struct {
+	Level      FindingLevel `json:"level"`
+	Rule       string       `json:"rule"`
+	Target     string       `json:"target"`
+	Context    *string      `json:"context,omitempty"`
+	Message    string       `json:"message"`
+	Suggestion *string      `json:"suggestion,omitempty"`
+}
+
+type Summary struct {
+	Failures int `json:"failures"`
+	Warnings int `json:"warnings"`
+}
+
+type ScanResult struct {
+	Target   ScanTarget `json:"target"`
+	Findings []Finding  `json:"findings"`
+	Summary  Summary    `json:"summary"`
+}

--- a/cli/wasm/wazero.go
+++ b/cli/wasm/wazero.go
@@ -1,0 +1,40 @@
+package wasm
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	"github.com/tetratelabs/wazero"
+)
+
+//go:embed papion.wasm
+var embeddedModule []byte
+
+type WazeroScanner struct {
+	module        []byte
+	runtimeConfig wazero.RuntimeConfig
+}
+
+func NewWazeroScanner() *WazeroScanner {
+	return &WazeroScanner{
+		module:        embeddedModule,
+		runtimeConfig: wazero.NewRuntimeConfig(),
+	}
+}
+
+func (s *WazeroScanner) Scan(target ScanTarget, yamlContent string, policyJSON string) (*ScanResult, error) {
+	return nil, fmt.Errorf("wazero scanner not implemented")
+}
+
+func (s *WazeroScanner) FormatHuman(result *ScanResult) (string, error) {
+	return "", fmt.Errorf("wazero scanner not implemented")
+}
+
+func (s *WazeroScanner) FormatJSON(result *ScanResult) (string, error) {
+	return "", fmt.Errorf("wazero scanner not implemented")
+}
+
+func (s *WazeroScanner) Close(ctx context.Context) error {
+	return nil
+}

--- a/cli/wasm/wazero_test.go
+++ b/cli/wasm/wazero_test.go
@@ -1,0 +1,95 @@
+package wasm
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func strptr(s string) *string {
+	return &s
+}
+
+func TestScanResultJSONRoundTrip(t *testing.T) {
+	original := ScanResult{
+		Target: ScanTarget{
+			Owner:  "actions",
+			Repo:   "checkout",
+			GitRef: "v4",
+		},
+		Findings: []Finding{
+			{
+				Level:      FindingLevelWarn,
+				Rule:       "sha-pinning",
+				Target:     "actions/checkout@v4",
+				Context:    strptr("composite step \"setup\""),
+				Message:    "Referenced by tag, not pinned to a SHA.",
+				Suggestion: strptr("actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683"),
+			},
+		},
+		Summary: Summary{
+			Failures: 0,
+			Warnings: 1,
+		},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	var decoded ScanResult
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if decoded.Target != original.Target {
+		t.Fatalf("target mismatch: %#v != %#v", decoded.Target, original.Target)
+	}
+	if len(decoded.Findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(decoded.Findings))
+	}
+	if decoded.Findings[0].Level != FindingLevelWarn {
+		t.Fatalf("unexpected finding level: %q", decoded.Findings[0].Level)
+	}
+	if decoded.Findings[0].Context == nil || *decoded.Findings[0].Context != *original.Findings[0].Context {
+		t.Fatalf("context mismatch: %#v", decoded.Findings[0].Context)
+	}
+	if decoded.Findings[0].Suggestion == nil || *decoded.Findings[0].Suggestion != *original.Findings[0].Suggestion {
+		t.Fatalf("suggestion mismatch: %#v", decoded.Findings[0].Suggestion)
+	}
+}
+
+func TestStubScannerReturnsCannedResult(t *testing.T) {
+	scanner := &StubScanner{}
+	target := ScanTarget{Owner: "actions", Repo: "checkout", GitRef: "v4"}
+
+	result, err := scanner.Scan(target, "name: checkout", `{"policy":{}}`)
+	if err != nil {
+		t.Fatalf("Scan returned error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.Target != target {
+		t.Fatalf("target mismatch: %#v != %#v", result.Target, target)
+	}
+	if len(result.Findings) == 0 {
+		t.Fatal("expected canned findings")
+	}
+
+	human, err := scanner.FormatHuman(result)
+	if err != nil {
+		t.Fatalf("FormatHuman returned error: %v", err)
+	}
+	if human == "" {
+		t.Fatal("expected non-empty human output")
+	}
+
+	jsonOut, err := scanner.FormatJSON(result)
+	if err != nil {
+		t.Fatalf("FormatJSON returned error: %v", err)
+	}
+	if !json.Valid([]byte(jsonOut)) {
+		t.Fatalf("expected valid json output, got %q", jsonOut)
+	}
+}


### PR DESCRIPTION
## Summary

- Go CLI host that wraps the MoonBit WASM core (Phase 3 of #2)
- `papion run org/repo@ref` command with `--format`, `--fail-on`, `--config` flags
- GitHub API client for downloading action archives; archive extractor for `action.yml`
- TOML config loader with fallback lookup order and TOML→JSON conversion
- `Scanner` interface with `StubScanner` (testing) and `WazeroScanner` skeleton (WS8)
- CI workflow: `.github/workflows/cli-test.yml`

> **Note:** `main.go` uses `StubScanner` intentionally — the real WASM artifact is deferred to WS8 when `core/engine` is wired in.

## Test plan

- [x] `go test ./...` — 22 tests pass across 5 packages
- [x] `go vet ./...` — no issues
- [ ] WS8 will replace `StubScanner` with `WazeroScanner` and run end-to-end tests

Closes #8
Tracking: #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)