### PR TITLE
NO-ISSUE docs: reframe CLI from Go+WASM to MoonBit native (Decision 18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,23 @@ If an action matches both `allowed` and `disallowed`, **disallowed takes precede
 ### Install
 
 ```sh
-go install github.com/maruloop/papion@latest
+# Homebrew
+brew install maruloop/tap/papion
+
+# Docker
+docker run --rm ghcr.io/maruloop/papion run actions/checkout@v4
+
+# From source
+git clone https://github.com/maruloop/papion.git
+cd papion
+moon build --target native
+cp ./target/native/release/build/cli/cli papion
 ```
 
 ### Usage
 
 ```sh
-papion run org/repo@ref
+papion run org/repo[/path]@ref
 ```
 
 **Examples:**
@@ -66,6 +76,9 @@ papion run actions/checkout@v4
 
 # Scan by SHA
 papion run actions/checkout@abc1234def5678
+
+# Scan a sub-path action (e.g. this repo's own action)
+papion run maruloop/papion/action@v1
 
 # Scan a specific version
 papion run actions/setup-go@v5.0.0
@@ -193,10 +206,19 @@ Override the ref to scan a specific tag or SHA:
 
 ## How it works
 
+Papion CLI is built as a MoonBit native binary, with a Docker image available as a fallback.
+
+CLI users do not need a Go or WASM runtime.
+
+The same MoonBit core for parsing, rules, and engine logic also compiles to WASM/JS for browser and Cloudflare Worker usage.
+
+At runtime Papion:
+
 1. Downloads the action archive from GitHub (no full clone)
-2. Parses `action.yml` and any composite steps
-3. Evaluates rules against all referenced actions
-4. Reports findings
+2. Resolves `org/repo[/path]@ref` to the target `action.yml`
+3. Parses `action.yml` and any composite steps
+4. Evaluates rules against all referenced actions
+5. Reports findings
 
 Scans run locally — no data is sent to any server.
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ If an action matches both `allowed` and `disallowed`, **disallowed takes precede
 # Homebrew
 brew install maruloop/tap/papion
 
+# GitHub Releases (macOS, Linux, Windows)
+# Download the binary for your platform from:
+# https://github.com/maruloop/papion/releases/latest
+curl -fsSL https://github.com/maruloop/papion/releases/latest/download/papion-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m) -o papion && chmod +x papion
+
 # Docker
 docker run --rm ghcr.io/maruloop/papion run actions/checkout@v4
 

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -480,6 +480,14 @@ For current architecture, transition CLI runtime to **MoonBit native binaries**,
 * Go+WASM remains historical context, not the active default
 * Browser and edge targets continue to use JS/WASM where appropriate
 
+### Consequence (expanded)
+
+* CLI host responsibilities (HTTP client, archive extraction, TOML loading) are implemented in MoonBit via C FFI (libcurl, libarchive, a TOML C library)
+* `path` in `owner/repo[/path]@ref` is resolved host-side: host extracts `<tarball-root>/<path>/action.yml` and passes raw YAML to core — `ScanTarget` stays as `{owner, repo, git_ref}`
+* Docker fallback: a pre-built image published to `ghcr.io/maruloop/papion` for platforms where native binary is unavailable
+* CI: `moon build --target native` added to CLI test workflow
+* Browser and edge targets (JS/WASM) are unaffected
+
 ---
 
 ## Final Architecture Summary


### PR DESCRIPTION
## Summary

- README: replace `go install` with Homebrew / Docker / from-source install paths
- README: update CLI usage to `org/repo[/path]@ref`, add sub-path example (`maruloop/papion/action@v1`)
- README: update "How it works" to describe MoonBit native binary + Docker fallback + shared core for JS/WASM
- ADR Decision 18: expand consequences (C FFI for host I/O, path handling, Docker definition, `moon build --target native` CI)

GitHub issues updated separately (no code changes):
- #2 progress section updated; Decision 18 note added
- #8 (WS6) reframed: MoonBit native CLI host layer
- #10 (WS8) reframed: integration tests
- #11 (WS9) updated: wrap native binary/Docker as GitHub Action

PR #27 (Go host layer) closed — superseded by Decision 18.

## Test plan

- [x] README renders correctly (no broken links or Go references)
- [x] ADR Decision 18 consequences are consistent with other decisions
- [x] Issues #2, #8, #10, #11 reflect new direction

🤖 Generated with [Claude Code](https://claude.com/claude-code)