### PR TITLE
WS8: cli/ — real host integrations and integration tests

### DIFF
--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -19,7 +19,29 @@ jobs:
       - run: moon update
       - run: moon fmt --check
       - run: moon test --deny-warn
+      - run: moon test --target native --deny-warn
       - name: Build native binary
         run: moon build --target native
+      - name: Smoke test - no args exits 2
+        run: |
+          set +e
+          ./_build/native/debug/build/cli/cli.exe
+          [ $? -eq 2 ]
+      - name: Smoke test - invalid target exits 2
+        run: |
+          set +e
+          ./_build/native/debug/build/cli/cli.exe run bad
+          [ $? -eq 2 ]
+      - name: Smoke test - real action
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set +e
+          ./_build/native/debug/build/cli/cli.exe \
+            run actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 \
+            --format json
+          code=$?
+          set -e
+          [ $code -eq 0 ] || [ $code -eq 1 ]
       - name: Check generated interface is up to date
         run: moon info && git diff --exit-code

--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -19,6 +19,7 @@ jobs:
       - run: moon update
       - run: moon fmt --check
       - run: moon test --deny-warn
+      - run: moon test --target native --deny-warn
       - run: moon build --target wasm-gc
       - run: moon build --target js
       - name: Check generated interface is up to date

--- a/core/cli/README.md
+++ b/core/cli/README.md
@@ -2,7 +2,7 @@
 
 `core/cli/` is the native host package for Papion. It is responsible for turning CLI input and host-side filesystem/network access into the pure data flow consumed by the core scan engine.
 
-WS6 delivers the package shape, argument parsing, orchestration, exit-code policy, and native build wiring. The C FFI surface for HTTP, archive extraction, and TOML parsing is intentionally stubbed in this workspace; real host integrations land in WS8.
+WS8 completes the real host integrations for GitHub Contents API fetch, action YAML decode, and TOML config loading, while preserving the WS6 package shape, argument parsing, orchestration, and exit-code policy.
 
 ## Package Role
 
@@ -29,7 +29,8 @@ Rules:
 - `ScanTarget` passed to the engine is `{ owner, repo, git_ref }`.
 - `--format` defaults to `human`.
 - `--fail-on` defaults to `fail`.
-- `--config` is optional. When omitted, default policy is used (no file lookup). Config file search (`papion.toml`, `.github/papion.toml`) is deferred to WS8.
+- `--config` is optional. When omitted, default policy is used.
+- The config path is explicit. Automatic config discovery (`papion.toml`, `.github/papion.toml`) is not part of this package yet.
 
 ## Responsibilities
 
@@ -43,12 +44,12 @@ These parts are covered by unit tests and run on the default `moon test` target.
 
 ### Native host integration
 
-- Download the action tarball from `https://codeload.github.com/{owner}/{repo}/tar.gz/{git_ref}`.
-- Extract `<tarball-root>[/path]/action.yml` from the tarball.
-- Load TOML config and convert it to JSON for `engine.scan`.
+- Fetch `{path/}action.yml` (fallback: `{path/}action.yaml`) from `https://api.github.com/repos/{owner}/{repo}/contents/{path/}action.yml?ref={git_ref}`, where `path/` is omitted for repository-root actions.
+- Decode the GitHub `content` field (base64) to raw action YAML bytes, then decode bytes as UTF-8.
+- Load TOML config directly into `@papion.Policy`.
 - Print formatted scan output.
 
-For WS6, these native pieces compile through C stubs and return placeholder errors where appropriate.
+These native pieces are implemented for native builds and remain stubbed on WASM targets.
 
 ## Package Layout
 
@@ -60,14 +61,14 @@ core/cli/
   main_wasm.mbt         # wasm stub entry point
   args.mbt              # argument parsing (CliError, RunOptions, parse_args)
   run.mbt               # orchestration (run, exit_code_for)
-  github_native.mbt     # fetch_tarball via C FFI
-  github_wasm.mbt       # fetch_tarball stub
-  archive_native.mbt    # extract_action_yml via C FFI
-  archive_wasm.mbt      # extract_action_yml stub
-  config_native.mbt     # load_config stub (C FFI deferred to WS8)
+  github_native.mbt     # fetch action.yml/action.yaml via GitHub Contents API and decode YAML text
+  github_wasm.mbt       # GitHub fetch stub
+  config_native.mbt     # load_config with native file read + TOML parsing
   config_wasm.mbt       # load_config stub
-  cwrap.c               # C glue stubs (papion_fetch_tarball, etc.)
+  fileio_native.mbt     # native file I/O helper (read_file) used by config loading
   cli_wbtest.mbt        # whitebox unit tests
+  testdata/
+    papion.toml
 ```
 
 ## Data Flow
@@ -75,38 +76,38 @@ core/cli/
 1. `main_native.mbt` reads CLI args and calls `run`.
 2. `args.mbt` parses `run` options; returns `ArgError` or `RuntimeError` on failure.
 3. `run.mbt` orchestrates host calls:
-   - fetch tarball
-   - extract `action.yml`
-   - load config JSON
+   - fetch `action.yml`/`action.yaml` bytes from GitHub Contents API
+   - decode YAML bytes to string
+   - load config policy
    - call `engine.scan`
    - format result
    - determine exit code
-4. `github_native.mbt`, `archive_native.mbt`, and `config_native.mbt` isolate native host dependencies.
+4. `github_native.mbt` and `config_native.mbt` isolate native host dependencies.
 
 ## Native Dependencies
 
-The package links native builds against:
+The package uses:
 
-- `libcurl`
-- `libarchive`
+- `moonbitlang/async/http` (+ `moonbitlang/async/tls`) for HTTPS requests to GitHub Contents API
+- `bobzhang/toml` for TOML parsing in MoonBit
+- libc file I/O through `fileio_native.mbt` for config file reads
 
-Config loading is a pure MoonBit stub in WS6; the C FFI boundary for TOML parsing is deferred to WS8.
+## Testdata Layout
 
-## WS6 Scope
+```text
+core/cli/testdata/
+  papion.toml
+```
 
-Implemented in this workspace:
+These TOML fixtures are used by whitebox tests for config loading.
 
-- README-driven package contract
-- tested CLI argument parsing
-- tested exit-code policy
-- native package wiring and buildability
-- stubbed host integrations with stable function signatures
+## Test Strategy
 
-Deferred to WS8:
-
-- real HTTP download via `libcurl`
-- real `tar.gz` extraction via `libarchive`
-- real TOML parsing and JSON conversion
+- Default `moon test` coverage is limited to target-agnostic logic that can run on the default MoonBit test target.
+- CLI host-layer tests in `cli_wbtest.mbt` cover parsing, orchestration, exit-code policy, and config loading, and they are native/LLVM-only.
+- Native-only host behavior is isolated behind `*_native.mbt` modules.
+- CI covers those native-only CLI tests with `moon test --target native --deny-warn`.
+- CI also builds the native binary and runs a small live smoke test against a real pinned GitHub Action reference.
 
 ## Exit Codes
 

--- a/core/cli/archive_native.mbt
+++ b/core/cli/archive_native.mbt
@@ -1,7 +1,0 @@
-///|
-pub fn extract_action_yml(
-  _tarball : Bytes,
-  _path : String?,
-) -> Result[String, String] {
-  Err("tar.gz extraction is not implemented in WS6")
-}

--- a/core/cli/archive_wasm.mbt
+++ b/core/cli/archive_wasm.mbt
@@ -1,7 +1,0 @@
-///|
-pub fn extract_action_yml(
-  _tarball : Bytes,
-  _path : String?,
-) -> Result[String, String] {
-  Err("tar.gz extraction is not implemented in WS6")
-}

--- a/core/cli/cli_wbtest.mbt
+++ b/core/cli/cli_wbtest.mbt
@@ -225,27 +225,70 @@ test "parse_args split_target error empty ref" {
 }
 
 ///|
-test "run propagates fetch stub error as RuntimeError" {
-  let result = run(["run", "actions/checkout@v4"])
-  assert_eq(
-    result,
-    Err(RuntimeError("GitHub tarball fetch is not implemented in WS6")),
-  )
-}
-
-///|
 test "run propagates arg error as ArgError" {
   let result = run(["run"])
   assert_eq(result, Err(ArgError("missing command and target")))
 }
 
 ///|
-test "run config stub error fires before fetch stub error" {
-  let result = run(["run", "actions/checkout@v4", "--config", "papion.toml"])
-  assert_eq(
-    result,
-    Err(RuntimeError("config loading is not implemented in WS6")),
+test "load_config none returns default policy" {
+  assert_eq(load_config(None), Ok(@papion.Policy::default()))
+}
+
+///|
+test "load_config parses TOML fixture into policy" {
+  let policy = match load_config(Some("cli/testdata/papion.toml")) {
+    Ok(policy) => policy
+    Err(err) => fail(err)
+  }
+  assert_eq(policy, {
+    sha_pinning: false,
+    allowed: ["actions/*", "github/*"],
+    disallowed: ["bad-org/unsafe"],
+  })
+}
+
+///|
+test "load_config normalizes TOML patterns via shared policy helper" {
+  let value = try? @toml.parse(
+    (
+      #|[policy]
+      #|allowed = ["Actions/*"]
+      #|disallowed = ["Bad-Org/Unsafe"]
+    ),
   )
+  let policy = match value {
+    Ok(value) =>
+      match parse_policy_toml(value) {
+        Ok(policy) => policy
+        Err(err) => fail(err)
+      }
+    Err(err) => fail(err.to_string())
+  }
+  assert_eq(policy.allowed, ["actions/*"])
+  assert_eq(policy.disallowed, ["bad-org/unsafe"])
+}
+
+///|
+test "github_contents_url encodes ref query parameter" {
+  let url = match
+    github_contents_url("maruloop", "papion", "release/a&b", "action.yml") {
+    Ok(url) => url
+    Err(err) => fail(err.1)
+  }
+  assert_eq(
+    url, "https://api.github.com/repos/maruloop/papion/contents/action.yml?ref=release%2Fa%26b",
+  )
+}
+
+///|
+test "run config error fires before fetch" {
+  match
+    run(["run", "actions/checkout@v4", "--config", "cli/testdata/missing.toml"]) {
+    Err(RuntimeError(_)) => ()
+    Ok(_) => fail("expected RuntimeError for missing config")
+    Err(ArgError(_)) => fail("expected RuntimeError for missing config")
+  }
 }
 
 ///|

--- a/core/cli/config_native.mbt
+++ b/core/cli/config_native.mbt
@@ -1,7 +1,72 @@
 ///|
-pub fn load_config(config_path : String?) -> Result[String, String] {
+fn parse_pattern_list(
+  value : @toml.TomlValue?,
+  field_name : String,
+) -> Result[Array[String], String] {
+  match value {
+    None => Ok([])
+    Some(@toml.TomlArray(items)) => {
+      let acc : Array[String] = []
+      for item in items {
+        match item {
+          @toml.TomlString(s) => acc.push(s)
+          _ => return Err("invalid entry in '\{field_name}': expected string")
+        }
+      }
+      Ok(acc)
+    }
+    Some(_) => Err("invalid '\{field_name}' field: expected array")
+  }
+}
+
+///|
+fn parse_policy_toml(value : @toml.TomlValue) -> Result[@papion.Policy, String] {
+  let root = match value {
+    @toml.TomlTable(entries) => entries
+    _ => return Err("expected TOML table for Policy")
+  }
+  let obj = match root.get("policy") {
+    None => root
+    Some(@toml.TomlTable(inner)) => inner
+    Some(_) => return Err("invalid 'policy' field: expected table")
+  }
+  let sha_pinning = match obj.get("sha_pinning") {
+    Some(@toml.TomlBoolean(b)) => b
+    None => true
+    Some(_) => return Err("invalid 'sha_pinning' field: expected boolean")
+  }
+  let allowed = match parse_pattern_list(obj.get("allowed"), "allowed") {
+    Ok(allowed) => allowed
+    Err(err) => return Err(err)
+  }
+  let disallowed = match
+    parse_pattern_list(obj.get("disallowed"), "disallowed") {
+    Ok(disallowed) => disallowed
+    Err(err) => return Err(err)
+  }
+  @papion.Policy::{ sha_pinning, allowed, disallowed }.normalized()
+}
+
+///|
+pub fn load_config(config_path : String?) -> Result[@papion.Policy, String] {
   match config_path {
-    None => Ok("{}")
-    Some(_) => Err("config loading is not implemented in WS6")
+    None => Ok(@papion.Policy::default())
+    Some(path) => {
+      let bytes = match read_file(path) {
+        Ok(bytes) => bytes
+        Err(err) => return Err(err)
+      }
+      let toml_str = try? @utf8.decode(bytes)
+      match toml_str {
+        Ok(toml_str) => {
+          let value = try? @toml.parse(toml_str)
+          match value {
+            Ok(value) => parse_policy_toml(value)
+            Err(err) => Err(err.to_string())
+          }
+        }
+        Err(_) => Err("config file is not valid UTF-8: \{path}")
+      }
+    }
   }
 }

--- a/core/cli/config_wasm.mbt
+++ b/core/cli/config_wasm.mbt
@@ -1,7 +1,7 @@
 ///|
-pub fn load_config(config_path : String?) -> Result[String, String] {
+pub fn load_config(config_path : String?) -> Result[@papion.Policy, String] {
   match config_path {
-    None => Ok("{}")
-    Some(_) => Err("config loading is not implemented in WS6")
+    None => Ok(@papion.Policy::default())
+    Some(_) => Err("config loading is not available on WASM targets")
   }
 }

--- a/core/cli/fileio_native.mbt
+++ b/core/cli/fileio_native.mbt
@@ -1,0 +1,104 @@
+///|
+#borrow(path, mode)
+extern "c" fn fopen_ffi(path : Bytes, mode : Bytes) -> Int64 = "moonbit_fopen_ffi"
+
+///|
+#borrow(ptr)
+extern "c" fn is_null_ffi(ptr : Int64) -> Bool = "moonbit_is_null"
+
+///|
+#borrow(ptr)
+extern "c" fn fread_ffi(
+  ptr : Bytes,
+  size : Int64,
+  nitems : Int64,
+  stream : Int64,
+) -> Int64 = "moonbit_fread_ffi"
+
+///|
+extern "c" fn fseek_ffi(stream : Int64, offset : Int64, whence : Int) -> Int = "moonbit_fseek_ffi"
+
+///|
+extern "c" fn ftell_ffi(stream : Int64) -> Int64 = "moonbit_ftell_ffi"
+
+///|
+extern "c" fn fclose_ffi(stream : Int64) -> Int = "moonbit_fclose_ffi"
+
+///|
+extern "c" fn get_error_message_ffi() -> Bytes = "moonbit_get_error_message"
+
+///|
+let seek_set : Int = 0
+
+///|
+let seek_end : Int = 2
+
+///|
+fn c_string_bytes(str : String) -> Bytes {
+  let bytes = @utf8.encode(str).to_array()
+  bytes.push(0)
+  Bytes::from_array(bytes)
+}
+
+///|
+let max_config_file_size : Int64 = 10L * 1024L * 1024L
+
+///|
+let file_read_chunk_size : Int64 = 8192L
+
+///|
+fn read_file(path : String) -> Result[Bytes, String] {
+  let file = fopen_ffi(c_string_bytes(path), b"rb")
+  if is_null_ffi(file) {
+    return Err(
+      "failed to open \{path}: \{@utf8.decode_lossy(get_error_message_ffi())}",
+    )
+  }
+  if fseek_ffi(file, 0L, seek_end) != 0 {
+    ignore(fclose_ffi(file))
+    return Err("failed to seek to end of \{path}")
+  }
+  let size = ftell_ffi(file)
+  if size < 0L {
+    ignore(fclose_ffi(file))
+    return Err("failed to get size of \{path}")
+  }
+  if size > max_config_file_size {
+    ignore(fclose_ffi(file))
+    return Err("config file exceeds maximum size of 10 MiB: \{path}")
+  }
+  if fseek_ffi(file, 0L, seek_set) != 0 {
+    ignore(fclose_ffi(file))
+    return Err("failed to seek to start of \{path}")
+  }
+  let buffer = @buffer.new(size_hint=size.to_int())
+  let chunk = Bytes::new(
+    if size < file_read_chunk_size {
+      size.to_int()
+    } else {
+      file_read_chunk_size.to_int()
+    },
+  )
+  let mut total_read = 0L
+  while total_read < size {
+    let remaining = size - total_read
+    let n = fread_ffi(
+      chunk,
+      1L,
+      if remaining < file_read_chunk_size {
+        remaining
+      } else {
+        file_read_chunk_size
+      },
+      file,
+    )
+    if n <= 0L {
+      ignore(fclose_ffi(file))
+      return Err("failed to read \{path}")
+    }
+    buffer.write_bytesview(chunk[:n.to_int()])
+    total_read = total_read + n
+  }
+  ignore(fclose_ffi(file))
+  Ok(buffer.to_bytes())
+}

--- a/core/cli/github_native.mbt
+++ b/core/cli/github_native.mbt
@@ -1,8 +1,143 @@
 ///|
-pub fn fetch_tarball(
-  _owner : String,
-  _repo : String,
-  _git_ref : String,
-) -> Result[Bytes, String] {
-  Err("GitHub tarball fetch is not implemented in WS6")
+fn decode_base64_content(content : String) -> Result[Bytes, String] {
+  Ok(@base64.decode(content, ignore_whitespace=true)) catch {
+    _ => Err("failed to decode GitHub contents payload")
+  }
+}
+
+///|
+fn extract_content_field(
+  body : String,
+  path : String,
+) -> Result[Bytes, (Int, String)] {
+  let json = try? @json.parse(body)
+  let json = match json {
+    Ok(json) => json
+    Err(err) =>
+      return Err((0, "failed to parse GitHub response for \{path}: \{err}"))
+  }
+  match json {
+    { "content": String(content), .. } =>
+      decode_base64_content(content).map_err(fn(message) { (0, message) })
+    { "content": _, .. } =>
+      Err(
+        (
+          0,
+          "GitHub response for \{path} did not contain a string content field",
+        ),
+      )
+    _ => Err((0, "GitHub response for \{path} did not contain a content field"))
+  }
+}
+
+///|
+fn github_token() -> String? {
+  match @env.get_env_var("GITHUB_TOKEN") {
+    Some("") => None
+    token => token
+  }
+}
+
+///|
+fn github_contents_url(
+  owner : String,
+  repo : String,
+  git_ref : String,
+  filename : String,
+) -> Result[String, (Int, String)] {
+  try {
+    let url = @url.Url::parse("https://api.github.com")
+    url.set_pathname("/repos/\{owner}/\{repo}/contents/\{filename}")
+    let params = @url.UrlSearchParams::new()
+    params.set("ref", git_ref)
+    url.set_search_params(params)
+    Ok(url.to_string())
+  } catch {
+    _ => Err((0, "failed to build GitHub contents URL for \{filename}"))
+  }
+}
+
+///|
+fn fetch_contents(
+  owner : String,
+  repo : String,
+  git_ref : String,
+  filename : String,
+) -> Result[Bytes, (Int, String)] {
+  let url = match github_contents_url(owner, repo, git_ref, filename) {
+    Ok(url) => url
+    Err(err) => return Err(err)
+  }
+  let mut result : Result[Bytes, (Int, String)] = Err(
+    (0, "request was not executed"),
+  )
+  @async.run_async_main(() => {
+    let headers = {
+      "User-Agent": @papion.cli_user_agent(),
+      "Accept": "application/vnd.github+json",
+    }
+    if github_token() is Some(token) {
+      headers["Authorization"] = "Bearer \{token}"
+    }
+    let request : Result[Unit, (Int, String)] = try {
+      let (response, body) = @http.get(url, headers~)
+      if response.code == 200 {
+        result = extract_content_field(body.text(), filename)
+      } else {
+        result = Err(
+          (
+            response.code,
+            "failed to fetch \{filename} from GitHub (\{response.code} \{response.reason})",
+          ),
+        )
+      }
+      Ok(())
+    } catch {
+      err => Err((0, "failed to fetch \{filename} from GitHub: \{err}"))
+    }
+    if request is Err(err) {
+      result = Err(err)
+    }
+  })
+  result
+}
+
+///|
+fn normalize_action_path(path : String?) -> String {
+  match path {
+    None => ""
+    Some(p) => {
+      let trimmed = p.trim(chars="/")
+      if trimmed.is_empty() {
+        ""
+      } else {
+        "\{trimmed}/"
+      }
+    }
+  }
+}
+
+///|
+pub fn fetch_action_yml(
+  owner : String,
+  repo : String,
+  git_ref : String,
+  path : String?,
+) -> Result[String, String] {
+  let prefix = normalize_action_path(path)
+  let bytes = match
+    fetch_contents(owner, repo, git_ref, "\{prefix}action.yml") {
+    Ok(bytes) => bytes
+    Err((404, _)) =>
+      match fetch_contents(owner, repo, git_ref, "\{prefix}action.yaml") {
+        Ok(bytes) => bytes
+        Err((_, err)) => return Err(err)
+      }
+    Err((_, err)) => return Err(err)
+  }
+  let action_yml = try? @utf8.decode(bytes)
+  match action_yml {
+    Ok(action_yml) => Ok(action_yml)
+    Err(_) => Err("GitHub action file is not valid UTF-8")
+  }
 }

--- a/core/cli/github_wasm.mbt
+++ b/core/cli/github_wasm.mbt
@@ -1,8 +1,9 @@
 ///|
-pub fn fetch_tarball(
+pub fn fetch_action_yml(
   _owner : String,
   _repo : String,
   _git_ref : String,
-) -> Result[Bytes, String] {
-  Err("GitHub tarball fetch is not implemented in WS6")
+  _path : String?,
+) -> Result[String, String] {
+  Err("GitHub action fetch is not available on WASM targets")
 }

--- a/core/cli/moon.pkg
+++ b/core/cli/moon.pkg
@@ -2,16 +2,30 @@ import {
   "maruloop/papion/engine",
   "maruloop/papion/format",
   "maruloop/papion",
+  "moonbitlang/async",
+  "moonbitlang/async/http",
+  "moonbitlang/core/buffer",
   "moonbitlang/core/env",
+  "moonbitlang/core/encoding/base64",
+  "moonbitlang/core/encoding/utf8",
+  "moonbitlang/core/json",
+  "tonyfettes/url",
+  "bobzhang/toml",
 }
+
+// Temporary package-wide suppression for a MoonBit false positive on target-
+// split imports in this package. Issue #37 tracks replacing this with a
+// narrower workaround once the toolchain supports it cleanly.
+
+warnings = "-unused_package"
 
 options(
   "is-main": true,
   targets: {
-    "archive_native.mbt": [ "native", "llvm" ],
-    "archive_wasm.mbt": [ "wasm", "wasm-gc", "js" ],
+    "cli_wbtest.mbt": [ "native", "llvm" ],
     "config_native.mbt": [ "native", "llvm" ],
     "config_wasm.mbt": [ "wasm", "wasm-gc", "js" ],
+    "fileio_native.mbt": [ "native", "llvm" ],
     "github_native.mbt": [ "native", "llvm" ],
     "github_wasm.mbt": [ "wasm", "wasm-gc", "js" ],
     "main_native.mbt": [ "native", "llvm" ],

--- a/core/cli/pkg.generated.mbti
+++ b/core/cli/pkg.generated.mbti
@@ -9,11 +9,9 @@ import {
 // Values
 pub fn exit_code_for(@papion.Summary, FailOnLevel) -> Int
 
-pub fn extract_action_yml(Bytes, String?) -> Result[String, String]
+pub fn fetch_action_yml(String, String, String, String?) -> Result[String, String]
 
-pub fn fetch_tarball(String, String, String) -> Result[Bytes, String]
-
-pub fn load_config(String?) -> Result[String, String]
+pub fn load_config(String?) -> Result[@papion.Policy, String]
 
 pub fn parse_args(Array[String]) -> Result[RunOptions, CliError]
 

--- a/core/cli/run.mbt
+++ b/core/cli/run.mbt
@@ -28,16 +28,12 @@ pub fn run(args : Array[String]) -> Result[RunOutcome, CliError] {
     Ok(options) => options
     Err(err) => return Err(err)
   }
-  let config_json = match load_config(options.config) {
-    Ok(config_json) => config_json
+  let policy = match load_config(options.config) {
+    Ok(policy) => policy
     Err(err) => return Err(RuntimeError(err))
   }
-  let tarball = match
-    fetch_tarball(options.owner, options.repo, options.git_ref) {
-    Ok(tarball) => tarball
-    Err(err) => return Err(RuntimeError(err))
-  }
-  let action_yml = match extract_action_yml(tarball, options.path) {
+  let action_yml = match
+    fetch_action_yml(options.owner, options.repo, options.git_ref, options.path) {
     Ok(action_yml) => action_yml
     Err(err) => return Err(RuntimeError(err))
   }
@@ -45,7 +41,7 @@ pub fn run(args : Array[String]) -> Result[RunOutcome, CliError] {
     @engine.scan(
       { owner: options.owner, repo: options.repo, git_ref: options.git_ref },
       action_yml,
-      config_json,
+      policy,
     ) {
     Ok(result) => result
     Err(err) => return Err(RuntimeError(err))

--- a/core/cli/testdata/papion.toml
+++ b/core/cli/testdata/papion.toml
@@ -1,0 +1,4 @@
+[policy]
+sha_pinning = false
+allowed = ["Actions/*", "GitHub/*"]
+disallowed = ["Bad-Org/Unsafe"]

--- a/core/config/config.mbt
+++ b/core/config/config.mbt
@@ -4,7 +4,7 @@
 /// The host converts TOML to JSON before passing to this function.
 /// Missing fields use defaults: sha_pinning=true, allowed=[], disallowed=[].
 /// Returns Err if any pattern exceeds 256 characters.
-/// Patterns are normalized to lowercase during parsing.
+/// Patterns are normalized to lowercase before returning.
 pub fn parse_policy(json_str : String) -> Result[@papion.Policy, String] {
   try {
     let json = @json.parse(json_str)
@@ -25,46 +25,32 @@ pub fn parse_policy(json_str : String) -> Result[@papion.Policy, String] {
     let allowed = match obj.get("allowed") {
       None => []
       Some(Array(arr)) => {
-        let acc : Array[String] = Array::new()
+        let patterns : Array[String] = []
         for item in arr {
           match item {
-            String(s) => {
-              if s.length() > max_pattern_len {
-                return Err(
-                  "pattern too long in 'allowed': \{s.length()} chars (max \{max_pattern_len})",
-                )
-              }
-              acc.push(s.to_lower())
-            }
+            String(s) => patterns.push(s)
             _ => return Err("invalid entry in 'allowed': expected string")
           }
         }
-        acc
+        patterns
       }
       Some(_) => return Err("invalid 'allowed' field: expected array")
     }
     let disallowed = match obj.get("disallowed") {
       None => []
       Some(Array(arr)) => {
-        let acc : Array[String] = Array::new()
+        let patterns : Array[String] = []
         for item in arr {
           match item {
-            String(s) => {
-              if s.length() > max_pattern_len {
-                return Err(
-                  "pattern too long in 'disallowed': \{s.length()} chars (max \{max_pattern_len})",
-                )
-              }
-              acc.push(s.to_lower())
-            }
+            String(s) => patterns.push(s)
             _ => return Err("invalid entry in 'disallowed': expected string")
           }
         }
-        acc
+        patterns
       }
       Some(_) => return Err("invalid 'disallowed' field: expected array")
     }
-    Ok({ sha_pinning, allowed, disallowed })
+    @papion.Policy::{ sha_pinning, allowed, disallowed }.normalized()
   } catch {
     e => Err(e.to_string())
   }

--- a/core/engine/README.mbt.md
+++ b/core/engine/README.mbt.md
@@ -8,20 +8,26 @@ Scan orchestrator. Wires parser, config, and rules into a single entry point.
 pub fn scan(
   target : @papion.ScanTarget,
   action_yml_yaml : String,
-  config_json : String,
+  policy : @papion.Policy,
 ) -> Result[@papion.ScanResult, String]
 ```
 
 - `target` — the action being scanned (`owner`, `repo`, `git_ref`)
 - `action_yml_yaml` — raw YAML content of `action.yml`
-- `config_json` — papion policy as JSON (empty string uses defaults)
+- `policy` — papion policy; `scan` normalizes `allowed`/`disallowed` to lowercase and rejects patterns longer than 256 characters before evaluation
 
-Returns `Ok(ScanResult)` with findings and summary, or `Err(message)` if the YAML or config is unparseable.
+Returns `Ok(ScanResult)` with findings and summary, or `Err(message)` if the YAML is unparseable.
 
 ## Behaviour
 
+Before rule evaluation, `scan` normalizes and validates the policy so both CLI callers and programmatic callers share the same invariants:
+
+- `policy.allowed` and `policy.disallowed` are lowercased before glob matching
+- every allowed/disallowed pattern must be at most 256 characters
+- invalid policies fail fast with `Err(...)` rather than silently producing mismatched findings
+
 1. Parse `action_yml_yaml` with `@parser.parse_action_yml`
-2. Parse `config_json` with `@config.parse_policy` (empty string → default policy)
+2. Normalize and validate `policy`
 3. Extract action refs from composite steps with `@parser.extract_refs`
 4. Evaluate each ref against the policy with `@rules.evaluate`
 5. Count failures and warnings for the summary
@@ -32,6 +38,5 @@ Non-composite actions (e.g. `using: node20`) produce zero findings from ref extr
 ## Error handling
 
 - Invalid YAML → `Err("...")`
-- Invalid config JSON → `Err("...")`
 - Empty action_yml_yaml → `Err("empty YAML document")`
-- Empty config_json → uses default policy (sha_pinning=true, no allowed/disallowed lists)
+- Invalid policy invariant (for example overlong pattern) → `Err("...")`

--- a/core/engine/engine.mbt
+++ b/core/engine/engine.mbt
@@ -1,21 +1,22 @@
 ///|
 /// Scan an action against a policy.
 ///
-/// Parses action_yml_yaml (raw YAML) and config_json (JSON policy, empty = defaults),
-/// extracts all action refs from composite steps, evaluates each ref against the
-/// policy, and returns a ScanResult with aggregated findings and summary counts.
+/// Parses action_yml_yaml (raw YAML), extracts all action refs from composite
+/// steps, evaluates each ref against the provided policy, and returns a
+/// ScanResult with aggregated findings and summary counts.
+/// The policy is normalized and validated before evaluation so callers may
+/// pass either `parse_policy` output or a programmatically constructed Policy.
 pub fn scan(
   target : @papion.ScanTarget,
   action_yml_yaml : String,
-  config_json : String,
+  policy : @papion.Policy,
 ) -> Result[@papion.ScanResult, String] {
+  let policy = match policy.normalized() {
+    Ok(policy) => policy
+    Err(err) => return Err(err)
+  }
   let yml = match @parser.parse_action_yml(action_yml_yaml) {
     Ok(y) => y
-    Err(e) => return Err(e)
-  }
-  let effective_config = if config_json.is_empty() { "{}" } else { config_json }
-  let policy = match @config.parse_policy(effective_config) {
-    Ok(p) => p
     Err(e) => return Err(e)
   }
   let refs = @parser.extract_refs(yml)

--- a/core/engine/engine_test.mbt
+++ b/core/engine/engine_test.mbt
@@ -11,7 +11,7 @@ test "scan unpinned ref produces sha-pinning failure" {
     #|  using: composite
     #|  steps:
     #|    - uses: actions/checkout@v4
-  let result = scan(target, yaml_str, "")
+  let result = scan(target, yaml_str, @papion.Policy::default())
   match result {
     Err(e) => fail("unexpected error: \{e}")
     Ok(r) => {
@@ -36,7 +36,7 @@ test "scan pinned ref produces zero findings" {
     #|  using: composite
     #|  steps:
     #|    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-  let result = scan(target, yaml_str, "")
+  let result = scan(target, yaml_str, @papion.Policy::default())
   match result {
     Err(e) => fail("unexpected error: \{e}")
     Ok(r) => {
@@ -60,9 +60,12 @@ test "scan disallowed action produces failure" {
     #|  using: composite
     #|  steps:
     #|    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-  let config_json =
-    #|{"sha_pinning":true,"allowed":[],"disallowed":["actions/checkout"]}
-  let result = scan(target, yaml_str, config_json)
+  let policy : @papion.Policy = {
+    sha_pinning: true,
+    allowed: [],
+    disallowed: ["actions/checkout"],
+  }
+  let result = scan(target, yaml_str, policy)
   match result {
     Err(e) => fail("unexpected error: \{e}")
     Ok(r) => {
@@ -86,9 +89,12 @@ test "scan allowed list restricts to listed actions" {
     #|  steps:
     #|    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
     #|    - uses: third-party/action@11bd71901bbe5b1630ceea73d27597364c9af683
-  let config_json =
-    #|{"sha_pinning":true,"allowed":["actions/*"],"disallowed":[]}
-  let result = scan(target, yaml_str, config_json)
+  let policy : @papion.Policy = {
+    sha_pinning: true,
+    allowed: ["actions/*"],
+    disallowed: [],
+  }
+  let result = scan(target, yaml_str, policy)
   match result {
     Err(e) => fail("unexpected error: \{e}")
     Ok(r) => {
@@ -113,7 +119,7 @@ test "scan node action produces zero findings" {
     #|name: Setup Node
     #|runs:
     #|  using: node20
-  let result = scan(target, yaml_str, "")
+  let result = scan(target, yaml_str, @papion.Policy::default())
   match result {
     Err(e) => fail("unexpected error: \{e}")
     Ok(r) => {
@@ -138,7 +144,7 @@ test "scan multiple unpinned refs aggregates findings" {
     #|  steps:
     #|    - uses: actions/checkout@v4
     #|    - uses: actions/setup-node@v4
-  let result = scan(target, yaml_str, "")
+  let result = scan(target, yaml_str, @papion.Policy::default())
   match result {
     Err(e) => fail("unexpected error: \{e}")
     Ok(r) => {
@@ -155,28 +161,10 @@ test "scan invalid YAML returns error" {
     repo: "checkout",
     git_ref: "v4",
   }
-  let result = scan(target, ":\t bad\t:\n\t", "")
+  let result = scan(target, ":\t bad\t:\n\t", @papion.Policy::default())
   match result {
     Err(_) => ()
     Ok(_) => fail("expected error for invalid YAML")
-  }
-}
-
-///|
-test "scan invalid config JSON returns error" {
-  let target : @papion.ScanTarget = {
-    owner: "actions",
-    repo: "checkout",
-    git_ref: "v4",
-  }
-  let yaml_str =
-    #|name: My Action
-    #|runs:
-    #|  using: node20
-  let result = scan(target, yaml_str, "not json")
-  match result {
-    Err(_) => ()
-    Ok(_) => fail("expected error for invalid config JSON")
   }
 }
 
@@ -191,9 +179,57 @@ test "scan result target matches input" {
     #|name: My Action
     #|runs:
     #|  using: node20
-  let result = scan(target, yaml_str, "")
+  let result = scan(target, yaml_str, @papion.Policy::default())
   match result {
     Err(e) => fail("unexpected error: \{e}")
     Ok(r) => assert_eq(r.target, target)
+  }
+}
+
+///|
+test "scan normalizes policy patterns before evaluation" {
+  let target : @papion.ScanTarget = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "v4",
+  }
+  let yaml_str =
+    #|name: My Action
+    #|runs:
+    #|  using: composite
+    #|  steps:
+    #|    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+  let policy : @papion.Policy = {
+    sha_pinning: true,
+    allowed: ["Actions/*"],
+    disallowed: [],
+  }
+  let result = scan(target, yaml_str, policy)
+  match result {
+    Err(e) => fail("unexpected error: \{e}")
+    Ok(r) => assert_eq(r.findings, [])
+  }
+}
+
+///|
+test "scan rejects overlong policy patterns" {
+  let target : @papion.ScanTarget = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "v4",
+  }
+  let long_pattern = String::make(@papion.max_policy_pattern_len + 1, 'a')
+  let yaml_str =
+    #|name: My Action
+    #|runs:
+    #|  using: node20
+  let policy : @papion.Policy = {
+    sha_pinning: true,
+    allowed: [long_pattern],
+    disallowed: [],
+  }
+  match scan(target, yaml_str, policy) {
+    Err(_) => ()
+    Ok(_) => fail("expected Err for overlong policy pattern")
   }
 }

--- a/core/engine/moon.pkg
+++ b/core/engine/moon.pkg
@@ -1,6 +1,5 @@
 import {
   "maruloop/papion",
   "maruloop/papion/parser",
-  "maruloop/papion/config",
   "maruloop/papion/rules",
 }

--- a/core/engine/pkg.generated.mbti
+++ b/core/engine/pkg.generated.mbti
@@ -6,7 +6,7 @@ import {
 }
 
 // Values
-pub fn scan(@papion.ScanTarget, String, String) -> Result[@papion.ScanResult, String]
+pub fn scan(@papion.ScanTarget, String, @papion.Policy) -> Result[@papion.ScanResult, String]
 
 // Errors
 

--- a/core/moon.mod.json
+++ b/core/moon.mod.json
@@ -2,7 +2,10 @@
   "name": "maruloop/papion",
   "version": "0.1.0",
   "deps": {
-    "moonbit-community/yaml": "0.0.4"
+    "bobzhang/toml": "0.2.0",
+    "moonbit-community/yaml": "0.0.4",
+    "moonbitlang/async": "0.18.0",
+    "tonyfettes/url": "0.3.1"
   },
   "readme": "README.mbt.md",
   "repository": "",

--- a/core/papion.mbt
+++ b/core/papion.mbt
@@ -1,4 +1,32 @@
 ///|
+pub let version : String = "0.1.0"
+
+///|
+pub let max_policy_pattern_len : Int = 256
+
+///|
+pub fn cli_user_agent() -> String {
+  "papion/\{version} (+https://github.com/maruloop/papion)"
+}
+
+///|
+fn normalize_policy_patterns(
+  patterns : Array[String],
+  field_name : String,
+) -> Result[Array[String], String] {
+  let normalized : Array[String] = []
+  for pattern in patterns {
+    if pattern.length() > max_policy_pattern_len {
+      return Err(
+        "pattern too long in '\{field_name}': \{pattern.length()} chars (max \{max_policy_pattern_len})",
+      )
+    }
+    normalized.push(pattern.to_lower())
+  }
+  Ok(normalized)
+}
+
+///|
 pub(all) struct ActionRef {
   owner : String
   repo : String
@@ -99,6 +127,20 @@ pub impl Show for Policy with output(self, logger) {
 ///|
 pub fn Policy::default() -> Policy {
   { sha_pinning: true, allowed: [], disallowed: [] }
+}
+
+///|
+pub fn Policy::normalized(self : Policy) -> Result[Policy, String] {
+  let allowed = match normalize_policy_patterns(self.allowed, "allowed") {
+    Ok(patterns) => patterns
+    Err(err) => return Err(err)
+  }
+  let disallowed = match
+    normalize_policy_patterns(self.disallowed, "disallowed") {
+    Ok(patterns) => patterns
+    Err(err) => return Err(err)
+  }
+  Ok({ ..self, allowed, disallowed })
 }
 
 ///|

--- a/core/papion_test.mbt
+++ b/core/papion_test.mbt
@@ -105,6 +105,37 @@ test "Policy defaults" {
 }
 
 ///|
+test "Policy normalized lowercases patterns" {
+  let policy : @papion.Policy = {
+    sha_pinning: true,
+    allowed: ["Actions/*"],
+    disallowed: ["Bad-Org/Unsafe"],
+  }
+  assert_eq(
+    policy.normalized(),
+    Ok({
+      sha_pinning: true,
+      allowed: ["actions/*"],
+      disallowed: ["bad-org/unsafe"],
+    }),
+  )
+}
+
+///|
+test "Policy normalized rejects overlong patterns" {
+  let long_pattern = String::make(@papion.max_policy_pattern_len + 1, 'a')
+  let policy : @papion.Policy = {
+    sha_pinning: true,
+    allowed: [long_pattern],
+    disallowed: [],
+  }
+  match policy.normalized() {
+    Err(_) => ()
+    Ok(_) => fail("expected Err for overlong policy pattern")
+  }
+}
+
+///|
 test "ActionYml json roundtrip - node action" {
   let a : @papion.ActionYml = {
     name: "Checkout",

--- a/core/pkg.generated.mbti
+++ b/core/pkg.generated.mbti
@@ -7,6 +7,11 @@ import {
 }
 
 // Values
+pub fn cli_user_agent() -> String
+
+pub let max_policy_pattern_len : Int
+
+pub let version : String
 
 // Errors
 
@@ -55,6 +60,7 @@ pub(all) struct Policy {
   disallowed : Array[String]
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn Policy::default() -> Self
+pub fn Policy::normalized(Self) -> Result[Self, String]
 pub impl Show for Policy
 
 pub(all) enum RefKind {

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -482,11 +482,50 @@ For current architecture, transition CLI runtime to **MoonBit native binaries**,
 
 ### Consequence (expanded)
 
-* CLI host responsibilities (HTTP client, archive extraction, TOML loading) are implemented in MoonBit via C FFI (libcurl, libarchive, a TOML C library)
-* `path` in `owner/repo[/path]@ref` is resolved host-side: host extracts `<tarball-root>/<path>/action.yml` and passes raw YAML to core — `ScanTarget` stays as `{owner, repo, git_ref}`
+* CLI host responsibilities (HTTP client, archive extraction, TOML loading) are implemented in MoonBit via C FFI and pure MoonBit libraries
+* `path` in `owner/repo[/path]@ref` is resolved host-side: host fetches `<path>/action.yml` or `<path>/action.yaml` via the GitHub Contents API and passes raw YAML to core — `ScanTarget` stays as `{owner, repo, git_ref}`
 * Docker fallback: a pre-built image published to `ghcr.io/maruloop/papion` for platforms where native binary is unavailable
 * CI: `moon build --target native` added to CLI test workflow
 * Browser and edge targets (JS/WASM) are unaffected
+
+---
+
+## Decision 19: CLI host integrations and integration-test strategy
+
+### Options
+
+* Keep the WS6 native host layer stubbed and defer end-to-end validation
+* Implement native host features with C library dependencies (libcurl, libarchive) for HTTP and archive extraction
+* Fetch the entire repository tarball and extract action.yml from it
+* Fetch only the single `action.yml` / `action.yaml` file directly from the GitHub Contents API
+
+### Decision
+
+Adopt the fourth option — fetch only the single file via the GitHub Contents API:
+
+* `GET https://api.github.com/repos/{owner}/{repo}/contents/{path}?ref={git_ref}` returns JSON with a base64-encoded `content` field
+* Try `action.yml` first, fall back to `action.yaml`
+* Decode base64 in pure MoonBit — no tar extraction needed at all
+* Use `moonbitlang/async/http` for HTTPS — no `libcurl`, no `libarchive`, no `apt-get install`
+* `moonbitlang/async/tls` loads OpenSSL via `dlopen()` at runtime (typically available on GitHub-hosted runners and most desktop/server macOS/Linux environments, but not guaranteed in minimal or distroless images; no dev headers required)
+* `bobzhang/toml` handles CLI config parsing in MoonBit
+* CLI integration tests hit the real GitHub Contents API in CI (no fixture tarballs needed)
+
+### Rationale
+
+* Papion only needs a single file (`action.yml` or `action.yaml`) — fetching the whole tarball was wasteful
+* The GitHub Contents API is simpler, faster, and requires no archive extraction
+* `moonbitlang/async/http` + `dlopen()` TLS eliminates all C library build-time dependencies
+* Pure MoonBit base64 decode is trivial and already available in `moonbitlang/core/encoding`
+* Fewer moving parts: one HTTP GET replaces tarball download + decompression + tar parsing
+
+### Consequence
+
+* Native CLI builds require no external development headers — `moon build --target native` works out of the box
+* CI drops the `apt-get install libcurl4-openssl-dev libarchive-dev` step entirely
+* `fileio_native.mbt` provides `fopen`/`fread` file I/O for config loading via libc — always available, no extra headers
+* For browser WASM / edge JS targets, the JS host must supply the fetch implementation via the existing `github_wasm.mbt` / `archive_wasm.mbt` stub boundary
+* The GitHub Contents API requires a valid `ref` (branch, tag, or full SHA) — all are supported
 
 ---
 


### PR DESCRIPTION
## Summary

Implements the three real host integrations deferred from WS6, plus fixture-backed integration tests.

- **GitHub Contents API** — `fetch_action_yml`: fetches `[path/]action.yml` / `action.yaml` directly from `api.github.com`
- **Policy loading** — `load_config`: pure MoonBit TOML parsing into `@papion.Policy`, no C dependency
- **Generated interfaces** — regenerated `core/cli/pkg.generated.mbti` and `core/engine/pkg.generated.mbti` to match the updated public signatures
- **CI smoke tests** against real `actions/checkout` via live network

Also adds ADR Decision 19 (host integration strategy) and updates `core/cli/README.md`.

Closes #10

## Test plan

- [x] `moon fmt --check` passes
- [x] `moon test --deny-warn` passes
- [x] `moon build --target native` succeeds
- [x] Smoke test: `cli.exe` → exits 2 (no args)
- [x] Smoke test: `cli.exe run actions/checkout@<sha> --format json` → exits 0, prints JSON
- [x] `moon info` — regenerated `core/cli/pkg.generated.mbti` and `core/engine/pkg.generated.mbti` to match the current signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)