### PR TITLE
fix(native): percent-encode URL components and add retry/timeout (#35, #36)

### DIFF
--- a/core/native/github.mbt
+++ b/core/native/github.mbt
@@ -39,6 +39,42 @@ fn github_token() -> String? {
 }
 
 ///|
+fn is_unreserved_path_byte(byte : Byte) -> Bool {
+  (byte >= b'A' && byte <= b'Z') ||
+  (byte >= b'a' && byte <= b'z') ||
+  (byte >= b'0' && byte <= b'9') ||
+  byte == b'-' ||
+  byte == b'.' ||
+  byte == b'_' ||
+  byte == b'~'
+}
+
+///|
+fn percent_encode_hex_digit(value : Byte) -> Char {
+  if value < 10 {
+    (value.to_int() + '0'.to_int()).unsafe_to_char()
+  } else {
+    (value.to_int() - 10 + 'A'.to_int()).unsafe_to_char()
+  }
+}
+
+///|
+fn percent_encode_path_component(component : String) -> String {
+  let bytes = @utf8.encode(component).to_array()
+  let builder = StringBuilder::new(size_hint=bytes.length() * 3)
+  for byte in bytes {
+    if is_unreserved_path_byte(byte) {
+      builder.write_char(byte.to_int().unsafe_to_char())
+    } else {
+      builder.write_char('%')
+      builder.write_char(percent_encode_hex_digit(byte / 16))
+      builder.write_char(percent_encode_hex_digit(byte % 16))
+    }
+  }
+  builder.to_string()
+}
+
+///|
 fn github_contents_url(
   owner : String,
   repo : String,
@@ -47,7 +83,14 @@ fn github_contents_url(
 ) -> Result[String, (Int, String)] {
   try {
     let url = @url.Url::parse("https://api.github.com")
-    url.set_pathname("/repos/\{owner}/\{repo}/contents/\{filename}")
+    let enc_owner = percent_encode_path_component(owner)
+    let enc_repo = percent_encode_path_component(repo)
+    let enc_filename = filename
+      .split("/")
+      .map(fn(segment) { percent_encode_path_component(segment.to_string()) })
+      .to_array()
+      .join("/")
+    url.set_pathname("/repos/\{enc_owner}/\{enc_repo}/contents/\{enc_filename}")
     let params = @url.UrlSearchParams::new()
     params.set("ref", git_ref)
     url.set_search_params(params)
@@ -55,6 +98,11 @@ fn github_contents_url(
   } catch {
     _ => Err((0, "failed to build GitHub contents URL for \{filename}"))
   }
+}
+
+///|
+priv suberror HttpError {
+  HttpError((Int, String))
 }
 
 ///|
@@ -79,24 +127,42 @@ fn fetch_contents(
     if github_token() is Some(token) {
       headers["Authorization"] = "Bearer \{token}"
     }
-    let request : Result[Unit, (Int, String)] = try {
-      let (response, body) = @http.get(url, headers~)
-      if response.code == 200 {
-        result = extract_content_field(body.text(), filename)
-      } else {
-        result = Err(
-          (
-            response.code,
-            "failed to fetch \{filename} from GitHub (\{response.code} \{response.reason})",
-          ),
-        )
-      }
-      Ok(())
+    let request : Result[Bytes, (Int, String)] = try {
+      let bytes = @async.retry(
+        ExponentialDelay(initial=1000, factor=2.0, maximum=10000),
+        max_retry=3,
+        fatal_error=fn(err) {
+          match err {
+            HttpError((code, _)) => code >= 400 && code < 500 && code != 429
+            _ => false
+          }
+        },
+        () => {
+          let pair = @async.with_timeout(30000, () => @http.get(url, headers~))
+          let (response, body) = pair
+          if response.code == 200 {
+            match extract_content_field(body.text(), filename) {
+              Ok(bytes) => bytes
+              Err(err) => raise HttpError(err)
+            }
+          } else {
+            raise HttpError(
+              (
+                response.code,
+                "failed to fetch \{filename} from GitHub (\{response.code} \{response.reason})",
+              ),
+            )
+          }
+        },
+      )
+      Ok(bytes)
     } catch {
+      HttpError(err) => Err(err)
       err => Err((0, "failed to fetch \{filename} from GitHub: \{err}"))
     }
-    if request is Err(err) {
-      result = Err(err)
+    match request {
+      Ok(bytes) => result = Ok(bytes)
+      Err(err) => result = Err(err)
     }
   })
   result

--- a/core/native/github.mbt
+++ b/core/native/github.mbt
@@ -129,11 +129,12 @@ fn fetch_contents(
     }
     let request : Result[Bytes, (Int, String)] = try {
       let bytes = @async.retry(
-        ExponentialDelay(initial=1000, factor=2.0, maximum=10000),
+        @async.ExponentialDelay(initial=1000, factor=2.0, maximum=10000),
         max_retry=3,
         fatal_error=fn(err) {
           match err {
-            HttpError((code, _)) => code >= 400 && code < 500 && code != 429
+            HttpError((code, _)) =>
+              code == 0 || (code >= 400 && code < 500 && code != 429)
             _ => false
           }
         },

--- a/core/native/native_wbtest.mbt
+++ b/core/native/native_wbtest.mbt
@@ -38,6 +38,34 @@ test "load_config normalizes TOML patterns via shared policy helper" {
 }
 
 ///|
+test "percent_encode_path_component: alphanumeric passthrough" {
+  assert_eq(percent_encode_path_component("actions"), "actions")
+}
+
+///|
+test "percent_encode_path_component: unreserved chars passthrough" {
+  assert_eq(
+    percent_encode_path_component("my.repo_name-v1~0"),
+    "my.repo_name-v1~0",
+  )
+}
+
+///|
+test "percent_encode_path_component: slash encoded" {
+  assert_eq(percent_encode_path_component("a/b"), "a%2Fb")
+}
+
+///|
+test "percent_encode_path_component: space encoded" {
+  assert_eq(percent_encode_path_component("hello world"), "hello%20world")
+}
+
+///|
+test "percent_encode_path_component: unicode encoded" {
+  assert_eq(percent_encode_path_component("café"), "caf%C3%A9")
+}
+
+///|
 test "github_contents_url encodes ref query parameter" {
   let url = match
     github_contents_url("maruloop", "papion", "release/a&b", "action.yml") {
@@ -46,6 +74,24 @@ test "github_contents_url encodes ref query parameter" {
   }
   assert_eq(
     url, "https://api.github.com/repos/maruloop/papion/contents/action.yml?ref=release%2Fa%26b",
+  )
+}
+
+///|
+test "github_contents_url encodes owner repo and path segments" {
+  let url = match
+    github_contents_url(
+      "maru/loop",
+      "pa pion",
+      "main",
+      "sub dir/action?.yml",
+    ) {
+    Ok(url) => url
+    Err(err) => fail(err.1)
+  }
+  assert_eq(
+    url,
+    "https://api.github.com/repos/maru%2Floop/pa%20pion/contents/sub%20dir/action%3F.yml?ref=main",
   )
 }
 

--- a/core/native/native_wbtest.mbt
+++ b/core/native/native_wbtest.mbt
@@ -80,18 +80,12 @@ test "github_contents_url encodes ref query parameter" {
 ///|
 test "github_contents_url encodes owner repo and path segments" {
   let url = match
-    github_contents_url(
-      "maru/loop",
-      "pa pion",
-      "main",
-      "sub dir/action?.yml",
-    ) {
+    github_contents_url("maru/loop", "pa pion", "main", "sub dir/action?.yml") {
     Ok(url) => url
     Err(err) => fail(err.1)
   }
   assert_eq(
-    url,
-    "https://api.github.com/repos/maru%2Floop/pa%20pion/contents/sub%20dir/action%3F.yml?ref=main",
+    url, "https://api.github.com/repos/maru%2Floop/pa%20pion/contents/sub%20dir/action%3F.yml?ref=main",
   )
 }
 


### PR DESCRIPTION
## Summary
- percent-encode GitHub contents URL owner, repo, and filename path segments
- add retry and timeout handling around native GitHub contents fetches
- add native whitebox tests for encoding behavior

Closes #35
Closes #36