### PR TITLE
feat(cli): support GitHub URLs without explicit refs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,6 +12,18 @@
 
 5. **Implement** — Write the minimal code to make tests pass, then refactor.
 
+## Layer responsibility boundaries
+
+The project has three layers (see ADR Decision 9). Each layer's types should only contain what that layer owns.
+
+- **Core** (`papion`, `engine`, `format`, `parser`, `rules`) — accepts only resolved, validated data. Types express invariants, not ambiguity. If scanning requires a ref, `ScanTarget.git_ref` is `String`, not `String?`.
+- **CLI** (`cli`) — parses user input, selects format/policy, orchestrates via injected host functions. Input-facing types like `RunOptions` may carry optionality (e.g. `git_ref: String?`) because user input is inherently ambiguous.
+- **Host** (`native`, `wasm`) — resolves ambiguity before constructing core types. Missing refs, tree URL probing, API calls, file I/O, and env vars are host responsibilities. The host produces clean, resolved values for the core.
+
+When a type pushes host-level concerns into the core (e.g. making a required field optional because the host hasn't resolved it yet), fix the boundary — don't preserve a leaky contract.
+
+Avoid bundling unrelated interface refactors into a bug fix or feature. If a broader change is needed, discuss first or file a follow-up issue.
+
 ## MoonBit code navigation
 
 Use `moon ide` for symbol lookup — do not grep or read files blindly.

--- a/core/cli/args.mbt
+++ b/core/cli/args.mbt
@@ -51,7 +51,8 @@ pub(all) struct RunOptions {
   owner : String
   repo : String
   path : String?
-  git_ref : String
+  git_ref : String?
+  allow_ref_fallback : Bool
   format : OutputFormat
   fail_on : FailOnLevel
   config : String?
@@ -68,49 +69,174 @@ pub impl Show for RunOptions with output(self, logger) {
   logger.write_string(", git_ref: ")
   self.git_ref.output(logger)
   logger.write_string(
-    ", format: \{self.format}, fail_on: \{self.fail_on}, config: ",
+    ", allow_ref_fallback: \{self.allow_ref_fallback}, format: \{self.format}, fail_on: \{self.fail_on}, config: ",
   )
   self.config.output(logger)
   logger.write_string(")")
 }
 
 ///|
-fn split_target(
-  target : String,
-) -> Result[(String, String, String?, String), String] {
-  guard target.rev_find("@") is Some(at_idx) else {
-    return Err("missing '@ref' in target: \"\{target}\"")
+priv struct ParsedTarget {
+  owner : String
+  repo : String
+  path : String?
+  git_ref : String?
+  allow_ref_fallback : Bool
+}
+
+///|
+fn parse_github_url_segments(url : String) -> Result[Array[String], String] {
+  let prefix = if url.has_prefix("https://github.com/") {
+    "https://github.com/"
+  } else if url.has_prefix("http://github.com/") {
+    "http://github.com/"
+  } else {
+    return Err("not a GitHub URL")
   }
-  let before_at = target[:at_idx].to_string()
-  let git_ref = target[at_idx + 1:].to_string()
-  guard git_ref != "" else {
-    return Err("missing '@ref' in target: \"\{target}\"")
+  let rest_with_suffix = url[prefix.length():].to_string()
+  let rest_without_query = match rest_with_suffix.find("?") {
+    Some(idx) => rest_with_suffix[:idx].to_string()
+    None => rest_with_suffix
   }
-  guard before_at.find("/") is Some(first_slash) else {
-    return Err("invalid target, expected org/repo[/path]@ref: \"\{target}\"")
+  let rest_without_fragment = match rest_without_query.find("#") {
+    Some(idx) => rest_without_query[:idx].to_string()
+    None => rest_without_query
   }
-  let owner = before_at[:first_slash].to_string()
-  guard owner != "" else {
-    return Err("invalid target, expected org/repo[/path]@ref: \"\{target}\"")
-  }
-  let rest = before_at[first_slash + 1:]
-  let (repo, path) = match rest.find("/") {
-    None => (rest.to_string(), None)
-    Some(path_slash) => {
-      let repo = rest[:path_slash].to_string()
-      let path = rest[path_slash + 1:].to_string()
-      guard path != "" else {
-        return Err(
-          "invalid target, expected org/repo[/path]@ref: \"\{target}\"",
-        )
-      }
-      (repo, Some(path))
+  let rest = rest_without_fragment.trim(chars="/")
+  let raw_segments = rest.split("/").map(fn(s) { s.to_string() }).to_array()
+  let segments : Array[String] = []
+  for raw_segment in raw_segments {
+    match percent_decode_url_path_segment(raw_segment) {
+      Ok(segment) => segments.push(segment)
+      Err(err) => return Err(err)
     }
   }
-  guard repo != "" else {
-    return Err("invalid target, expected org/repo[/path]@ref: \"\{target}\"")
+  guard segments.length() >= 2 &&
+    !segments[0].is_empty() &&
+    !segments[1].is_empty() else {
+    return Err("invalid GitHub URL: expected https://github.com/owner/repo")
   }
-  Ok((owner, repo, path, git_ref))
+  if segments[1].has_suffix(".git") {
+    segments[1] = segments[1][:segments[1].length() - 4].to_string()
+    if segments[1].is_empty() {
+      return Err("invalid GitHub URL: repo is empty")
+    }
+  }
+  Ok(segments)
+}
+
+///|
+fn parse_repo_target(segments : Array[String]) -> Result[ParsedTarget, String] {
+  if segments.length() > 2 {
+    if segments[2] == "blob" {
+      return Err(
+        "blob URLs are not supported; use tree URLs or owner/repo[/path]@ref format",
+      )
+    }
+    if segments[2] != "tree" {
+      return Err("invalid GitHub URL: expected repository root URL")
+    }
+  }
+  Ok({
+    owner: segments[0],
+    repo: segments[1],
+    path: None,
+    git_ref: None,
+    allow_ref_fallback: false,
+  })
+}
+
+///|
+fn parse_tree_target(segments : Array[String]) -> Result[ParsedTarget, String] {
+  if segments.length() < 4 || segments[3].is_empty() {
+    return Err("invalid GitHub URL: expected /tree/ref after owner/repo")
+  }
+  Ok({
+    owner: segments[0],
+    repo: segments[1],
+    path: if segments.length() > 4 {
+      Some(segments[4:].join("/"))
+    } else {
+      None
+    },
+    git_ref: Some(segments[3]),
+    allow_ref_fallback: true,
+  })
+}
+
+///|
+fn parse_owner_repo_path(
+  s : String,
+  git_ref : String?,
+) -> Result[ParsedTarget, String] {
+  match s.find("/") {
+    None => Err("invalid target: expected owner/repo")
+    Some(slash1) => {
+      let owner = s[:slash1].to_string()
+      if owner.is_empty() {
+        return Err("owner is empty")
+      }
+      let rest = s[slash1 + 1:].to_string()
+      match rest.find("/") {
+        None => {
+          if rest.is_empty() {
+            return Err("repo is empty")
+          }
+          Ok({
+            owner,
+            repo: rest,
+            path: None,
+            git_ref,
+            allow_ref_fallback: false,
+          })
+        }
+        Some(slash2) => {
+          let repo = rest[:slash2].to_string()
+          let path = rest[slash2 + 1:].to_string()
+          if repo.is_empty() {
+            return Err("repo is empty")
+          }
+          if path.is_empty() {
+            return Err("path is empty")
+          }
+          Ok({
+            owner,
+            repo,
+            path: Some(path),
+            git_ref,
+            allow_ref_fallback: false,
+          })
+        }
+      }
+    }
+  }
+}
+
+///|
+fn parse_target(target : String) -> Result[ParsedTarget, String] {
+  if target.has_prefix("https://github.com/") ||
+    target.has_prefix("http://github.com/") {
+    let segments = match parse_github_url_segments(target) {
+      Ok(segments) => segments
+      Err(err) => return Err(err)
+    }
+    if segments.length() >= 3 && segments[2] == "tree" {
+      parse_tree_target(segments)
+    } else {
+      parse_repo_target(segments)
+    }
+  } else {
+    match target.rev_find("@") {
+      Some(at_pos) => {
+        let git_ref = target[at_pos + 1:].to_string()
+        if git_ref.is_empty() {
+          return Err("missing ref after '@'")
+        }
+        parse_owner_repo_path(target[:at_pos].to_string(), Some(git_ref))
+      }
+      None => parse_owner_repo_path(target, None)
+    }
+  }
 }
 
 ///|
@@ -140,8 +266,8 @@ pub fn parse_args(args : Array[String]) -> Result[RunOptions, CliError] {
   guard args[0] == "run" else {
     return Err(ArgError("unknown command: \"\{args[0]}\""))
   }
-  let (owner, repo, path, git_ref) = match split_target(args[1]) {
-    Ok(parts) => parts
+  let target = match parse_target(args[1]) {
+    Ok(target) => target
     Err(err) => return Err(ArgError(err))
   }
   let mut format = Human
@@ -181,5 +307,14 @@ pub fn parse_args(args : Array[String]) -> Result[RunOptions, CliError] {
       _ => return Err(ArgError("unknown flag: \"\{flag}\""))
     }
   }
-  Ok({ owner, repo, path, git_ref, format, fail_on, config })
+  Ok({
+    owner: target.owner,
+    repo: target.repo,
+    path: target.path,
+    git_ref: target.git_ref,
+    allow_ref_fallback: target.allow_ref_fallback,
+    format,
+    fail_on,
+    config,
+  })
 }

--- a/core/cli/cli_test.mbt
+++ b/core/cli/cli_test.mbt
@@ -7,11 +7,25 @@ test "parse_args run owner repo ref" {
       owner: "actions",
       repo: "checkout",
       path: None,
-      git_ref: "v4",
+      git_ref: Some("v4"),
+      allow_ref_fallback: false,
       format: Human,
       fail_on: Fail,
       config: None,
     }),
+  )
+}
+
+///|
+test "percent_decode_url_path_segment decodes percent-escaped segment" {
+  assert_eq(percent_decode_url_path_segment("release%2Fv1"), Ok("release/v1"))
+}
+
+///|
+test "percent_decode_url_path_segment rejects invalid escape" {
+  assert_eq(
+    percent_decode_url_path_segment("release%"),
+    Err("invalid GitHub URL: invalid percent-encoding"),
   )
 }
 
@@ -24,7 +38,8 @@ test "parse_args run with path" {
       owner: "maruloop",
       repo: "papion",
       path: Some("action"),
-      git_ref: "v1",
+      git_ref: Some("v1"),
+      allow_ref_fallback: false,
       format: Human,
       fail_on: Fail,
       config: None,
@@ -41,7 +56,8 @@ test "parse_args json format" {
       owner: "actions",
       repo: "checkout",
       path: None,
-      git_ref: "v4",
+      git_ref: Some("v4"),
+      allow_ref_fallback: false,
       format: Json,
       fail_on: Fail,
       config: None,
@@ -58,7 +74,8 @@ test "parse_args fail_on warn" {
       owner: "actions",
       repo: "checkout",
       path: None,
-      git_ref: "v4",
+      git_ref: Some("v4"),
+      allow_ref_fallback: false,
       format: Human,
       fail_on: Warn,
       config: None,
@@ -75,7 +92,8 @@ test "parse_args fail_on none" {
       owner: "actions",
       repo: "checkout",
       path: None,
-      git_ref: "v4",
+      git_ref: Some("v4"),
+      allow_ref_fallback: false,
       format: Human,
       fail_on: NoneLevel,
       config: None,
@@ -92,7 +110,8 @@ test "parse_args short flag -f for format" {
       owner: "actions",
       repo: "checkout",
       path: None,
-      git_ref: "v4",
+      git_ref: Some("v4"),
+      allow_ref_fallback: false,
       format: Json,
       fail_on: Fail,
       config: None,
@@ -109,7 +128,8 @@ test "parse_args short flag -F for fail-on" {
       owner: "actions",
       repo: "checkout",
       path: None,
-      git_ref: "v4",
+      git_ref: Some("v4"),
+      allow_ref_fallback: false,
       format: Human,
       fail_on: Warn,
       config: None,
@@ -130,11 +150,116 @@ test "parse_args error command only" {
 }
 
 ///|
-test "parse_args error missing ref" {
+test "parse_args run owner repo without ref" {
   let result = parse_args(["run", "actions/checkout"])
   assert_eq(
     result,
-    Err(ArgError("missing '@ref' in target: \"actions/checkout\"")),
+    Ok({
+      owner: "actions",
+      repo: "checkout",
+      path: None,
+      git_ref: None,
+      allow_ref_fallback: false,
+      format: Human,
+      fail_on: Fail,
+      config: None,
+    }),
+  )
+}
+
+///|
+test "parse_args run github url without ref" {
+  let result = parse_args(["run", "https://github.com/actions/checkout"])
+  assert_eq(
+    result,
+    Ok({
+      owner: "actions",
+      repo: "checkout",
+      path: None,
+      git_ref: None,
+      allow_ref_fallback: false,
+      format: Human,
+      fail_on: Fail,
+      config: None,
+    }),
+  )
+}
+
+///|
+test "parse_args run github url ignores query and fragment" {
+  let result = parse_args([
+    "run", "https://github.com/actions/checkout?tab=readme#top",
+  ])
+  assert_eq(
+    result,
+    Ok({
+      owner: "actions",
+      repo: "checkout",
+      path: None,
+      git_ref: None,
+      allow_ref_fallback: false,
+      format: Human,
+      fail_on: Fail,
+      config: None,
+    }),
+  )
+}
+
+///|
+test "parse_args run github url strips trailing dot git" {
+  let result = parse_args(["run", "https://github.com/actions/checkout.git"])
+  assert_eq(
+    result,
+    Ok({
+      owner: "actions",
+      repo: "checkout",
+      path: None,
+      git_ref: None,
+      allow_ref_fallback: false,
+      format: Human,
+      fail_on: Fail,
+      config: None,
+    }),
+  )
+}
+
+///|
+test "parse_args run github tree url with ref and path" {
+  let result = parse_args([
+    "run", "https://github.com/actions/checkout/tree/v6.0.2/action",
+  ])
+  assert_eq(
+    result,
+    Ok({
+      owner: "actions",
+      repo: "checkout",
+      path: Some("action"),
+      git_ref: Some("v6.0.2"),
+      allow_ref_fallback: true,
+      format: Human,
+      fail_on: Fail,
+      config: None,
+    }),
+  )
+}
+
+///|
+test "parse_args run github tree url decodes percent-escaped ref and path" {
+  let result = parse_args([
+    "run", "https://github.com/actions/checkout/tree/release%2Fv1/sub%20dir",
+  ])
+  assert_eq(
+    result,
+    Ok({
+      owner: "actions",
+      repo: "checkout",
+      path: Some("sub dir"),
+      git_ref: Some("release/v1"),
+      allow_ref_fallback: true,
+      format: Human,
+      fail_on: Fail,
+      config: None,
+    }),
   )
 }
 
@@ -183,45 +308,46 @@ test "parse_args error invalid fail-on value" {
 ///|
 test "parse_args split_target error missing owner" {
   let result = parse_args(["run", "@v1"])
-  assert_eq(
-    result,
-    Err(ArgError("invalid target, expected org/repo[/path]@ref: \"@v1\"")),
-  )
+  assert_eq(result, Err(ArgError("invalid target: expected owner/repo")))
 }
 
 ///|
 test "parse_args split_target error empty owner" {
   let result = parse_args(["run", "/repo@v1"])
-  assert_eq(
-    result,
-    Err(ArgError("invalid target, expected org/repo[/path]@ref: \"/repo@v1\"")),
-  )
+  assert_eq(result, Err(ArgError("owner is empty")))
 }
 
 ///|
 test "parse_args split_target error empty repo" {
   let result = parse_args(["run", "org/@v1"])
-  assert_eq(
-    result,
-    Err(ArgError("invalid target, expected org/repo[/path]@ref: \"org/@v1\"")),
-  )
+  assert_eq(result, Err(ArgError("repo is empty")))
 }
 
 ///|
 test "parse_args split_target error empty path" {
   let result = parse_args(["run", "org/repo/@v1"])
-  assert_eq(
-    result,
-    Err(
-      ArgError("invalid target, expected org/repo[/path]@ref: \"org/repo/@v1\""),
-    ),
-  )
+  assert_eq(result, Err(ArgError("path is empty")))
 }
 
 ///|
 test "parse_args split_target error empty ref" {
   let result = parse_args(["run", "org/repo@"])
-  assert_eq(result, Err(ArgError("missing '@ref' in target: \"org/repo@\"")))
+  assert_eq(result, Err(ArgError("missing ref after '@'")))
+}
+
+///|
+test "parse_args github blob url is rejected" {
+  let result = parse_args([
+    "run", "https://github.com/actions/checkout/blob/main/action.yml",
+  ])
+  assert_eq(
+    result,
+    Err(
+      ArgError(
+        "blob URLs are not supported; use tree URLs or owner/repo[/path]@ref format",
+      ),
+    ),
+  )
 }
 
 ///|
@@ -234,14 +360,84 @@ test "run_with_host propagates arg error before host calls" {
       load_config_called = true
       Ok(@papion.Policy::default())
     },
-    fn(_owner, _repo, _git_ref, _path) {
+    fn(_owner, _repo, _git_ref, _path, _allow_ref_fallback) {
       fetch_called = true
-      Ok("")
+      Ok(("", "unused"))
     },
   )
   assert_eq(result, Err(ArgError("missing command and target")))
   assert_eq(load_config_called, false)
   assert_eq(fetch_called, false)
+}
+
+///|
+test "run_with_host uses resolved git ref from host fetch" {
+  let mut captured_owner = ""
+  let mut captured_repo = ""
+  let mut captured_git_ref = None
+  let mut captured_path = None
+  let mut captured_allow_ref_fallback = false
+  let result = run_with_host(
+    ["run", "actions/checkout@v4", "--format", "json"],
+    fn(_config_path) { Ok(@papion.Policy::default()) },
+    fn(owner, repo, git_ref, path, allow_ref_fallback) {
+      captured_owner = owner
+      captured_repo = repo
+      captured_git_ref = git_ref
+      captured_path = path
+      captured_allow_ref_fallback = allow_ref_fallback
+      Ok(
+        (
+          (
+            #|name: Setup Node
+            #|runs:
+            #|  using: node20
+          ),
+          "release/v1",
+        ),
+      )
+    },
+  )
+  match result {
+    Ok(outcome) => {
+      assert_eq(captured_owner, "actions")
+      assert_eq(captured_repo, "checkout")
+      assert_eq(captured_git_ref, Some("v4"))
+      assert_eq(captured_path, None)
+      assert_eq(captured_allow_ref_fallback, false)
+      assert_true(
+        outcome.output.contains("\"target\":\"actions/checkout@release/v1\""),
+      )
+      assert_true(outcome.output.contains("\"ref\":\"release/v1\""))
+    }
+    Err(err) => fail(err.to_string())
+  }
+}
+
+///|
+test "run_with_host passes allow_ref_fallback for github tree urls" {
+  let mut captured_allow_ref_fallback = false
+  let result = run_with_host(
+    ["run", "https://github.com/actions/checkout/tree/release/v1/action"],
+    fn(_config_path) { Ok(@papion.Policy::default()) },
+    fn(_owner, _repo, _git_ref, _path, allow_ref_fallback) {
+      captured_allow_ref_fallback = allow_ref_fallback
+      Ok(
+        (
+          (
+            #|name: Setup Node
+            #|runs:
+            #|  using: node20
+          ),
+          "release/v1",
+        ),
+      )
+    },
+  )
+  match result {
+    Ok(_) => assert_eq(captured_allow_ref_fallback, true)
+    Err(err) => fail(err.to_string())
+  }
 }
 
 ///|

--- a/core/cli/moon.pkg
+++ b/core/cli/moon.pkg
@@ -2,4 +2,6 @@ import {
   "maruloop/papion/engine",
   "maruloop/papion/format",
   "maruloop/papion",
+  "moonbitlang/core/buffer",
+  "moonbitlang/core/encoding/utf8",
 }

--- a/core/cli/pkg.generated.mbti
+++ b/core/cli/pkg.generated.mbti
@@ -11,7 +11,11 @@ pub fn exit_code_for(@papion.Summary, FailOnLevel) -> Int
 
 pub fn parse_args(Array[String]) -> Result[RunOptions, CliError]
 
-pub fn run_with_host(Array[String], (String?) -> Result[@papion.Policy, String], (String, String, String, String?) -> Result[String, String]) -> Result[RunOutcome, CliError]
+pub fn percent_decode_url_path_segment(String) -> Result[String, String]
+
+pub fn percent_encode_path_component(String) -> String
+
+pub fn run_with_host(Array[String], (String?) -> Result[@papion.Policy, String], (String, String, String?, String?, Bool) -> Result[(String, String), String]) -> Result[RunOutcome, CliError]
 
 // Errors
 
@@ -39,7 +43,8 @@ pub(all) struct RunOptions {
   owner : String
   repo : String
   path : String?
-  git_ref : String
+  git_ref : String?
+  allow_ref_fallback : Bool
   format : OutputFormat
   fail_on : FailOnLevel
   config : String?

--- a/core/cli/run.mbt
+++ b/core/cli/run.mbt
@@ -26,7 +26,10 @@ pub impl Show for RunOutcome with output(self, logger) {
 pub fn run_with_host(
   args : Array[String],
   load_config : (String?) -> Result[@papion.Policy, String],
-  fetch_action_yml : (String, String, String, String?) -> Result[String, String],
+  fetch_action_yml : (String, String, String?, String?, Bool) -> Result[
+    (String, String),
+    String,
+  ],
 ) -> Result[RunOutcome, CliError] {
   let options = match parse_args(args) {
     Ok(options) => options
@@ -36,14 +39,20 @@ pub fn run_with_host(
     Ok(policy) => policy
     Err(err) => return Err(RuntimeError(err))
   }
-  let action_yml = match
-    fetch_action_yml(options.owner, options.repo, options.git_ref, options.path) {
-    Ok(action_yml) => action_yml
+  let (action_yml, resolved_git_ref) = match
+    fetch_action_yml(
+      options.owner,
+      options.repo,
+      options.git_ref,
+      options.path,
+      options.allow_ref_fallback,
+    ) {
+    Ok(result) => result
     Err(err) => return Err(RuntimeError(err))
   }
   let result = match
     @engine.scan(
-      { owner: options.owner, repo: options.repo, git_ref: options.git_ref },
+      { owner: options.owner, repo: options.repo, git_ref: resolved_git_ref },
       action_yml,
       policy,
     ) {

--- a/core/cli/url_codec.mbt
+++ b/core/cli/url_codec.mbt
@@ -1,0 +1,86 @@
+///|
+fn hex_value(ch : Char) -> Int? {
+  if ch >= '0' && ch <= '9' {
+    Some(ch.to_int() - '0'.to_int())
+  } else if ch >= 'A' && ch <= 'F' {
+    Some(ch.to_int() - 'A'.to_int() + 10)
+  } else if ch >= 'a' && ch <= 'f' {
+    Some(ch.to_int() - 'a'.to_int() + 10)
+  } else {
+    None
+  }
+}
+
+///|
+pub fn percent_decode_url_path_segment(
+  segment : String,
+) -> Result[String, String] {
+  let bytes = @buffer.new(size_hint=segment.length())
+  let chars = segment.iter()
+  while chars.next() is Some(ch) {
+    if ch == '%' {
+      let hi = match chars.next() {
+        Some(ch) => ch
+        None => return Err("invalid GitHub URL: invalid percent-encoding")
+      }
+      let lo = match chars.next() {
+        Some(ch) => ch
+        None => return Err("invalid GitHub URL: invalid percent-encoding")
+      }
+      let hi = match hex_value(hi) {
+        Some(value) => value
+        None => return Err("invalid GitHub URL: invalid percent-encoding")
+      }
+      let lo = match hex_value(lo) {
+        Some(value) => value
+        None => return Err("invalid GitHub URL: invalid percent-encoding")
+      }
+      bytes.write_byte((hi * 16 + lo).to_byte())
+    } else if ch.to_int() <= 0x7F {
+      bytes.write_byte(ch.to_int().to_byte())
+    } else {
+      bytes.write_bytes(@utf8.encode([ch]))
+    }
+  }
+  let decoded : Result[String, _] = try? @utf8.decode(bytes.to_bytes())
+  match decoded {
+    Ok(decoded) => Ok(decoded)
+    Err(_) => Err("invalid GitHub URL: invalid UTF-8 in percent-encoding")
+  }
+}
+
+///|
+fn is_unreserved_path_byte(byte : Byte) -> Bool {
+  (byte >= b'A' && byte <= b'Z') ||
+  (byte >= b'a' && byte <= b'z') ||
+  (byte >= b'0' && byte <= b'9') ||
+  byte == b'-' ||
+  byte == b'.' ||
+  byte == b'_' ||
+  byte == b'~'
+}
+
+///|
+fn percent_encode_hex_digit(value : Byte) -> Char {
+  if value < 10 {
+    (value.to_int() + '0'.to_int()).unsafe_to_char()
+  } else {
+    (value.to_int() - 10 + 'A'.to_int()).unsafe_to_char()
+  }
+}
+
+///|
+pub fn percent_encode_path_component(component : String) -> String {
+  let bytes = @utf8.encode(component).to_array()
+  let builder = StringBuilder::new(size_hint=bytes.length() * 3)
+  for byte in bytes {
+    if is_unreserved_path_byte(byte) {
+      builder.write_char(byte.to_int().unsafe_to_char())
+    } else {
+      builder.write_char('%')
+      builder.write_char(percent_encode_hex_digit(byte / 16))
+      builder.write_char(percent_encode_hex_digit(byte % 16))
+    }
+  }
+  builder.to_string()
+}

--- a/core/format/format.mbt
+++ b/core/format/format.mbt
@@ -101,8 +101,9 @@ fn finding_to_json(f : @papion.Finding) -> Json {
 ///|
 /// Format a ScanResult as JSON.
 ///
-/// Target is serialized as "owner/repo@ref" string.
+/// Target is serialized as "owner/repo@ref".
 /// Level values are lowercase ("warn"/"fail").
+/// The top-level `ref` field always contains the resolved target ref.
 /// Optional finding fields (context, suggestion) are omitted when absent.
 pub fn format_json(result : @papion.ScanResult) -> String {
   let root : Map[String, Json] = {

--- a/core/native/github.mbt
+++ b/core/native/github.mbt
@@ -31,47 +31,47 @@ fn extract_content_field(
 }
 
 ///|
+fn extract_default_branch_field(
+  body : String,
+  owner : String,
+  repo : String,
+) -> Result[String, (Int, String)] {
+  let json = try? @json.parse(body)
+  let json = match json {
+    Ok(json) => json
+    Err(err) =>
+      return Err(
+        (
+          0,
+          "failed to parse GitHub repository response for \{owner}/\{repo}: \{err}",
+        ),
+      )
+  }
+  match json {
+    { "default_branch": String(branch), .. } => Ok(branch)
+    { "default_branch": _, .. } =>
+      Err(
+        (
+          0,
+          "GitHub repository response for \{owner}/\{repo} did not contain a string default_branch field",
+        ),
+      )
+    _ =>
+      Err(
+        (
+          0,
+          "GitHub repository response for \{owner}/\{repo} did not contain a default_branch field",
+        ),
+      )
+  }
+}
+
+///|
 fn github_token() -> String? {
   match @env.get_env_var("GITHUB_TOKEN") {
     Some("") => None
     token => token
   }
-}
-
-///|
-fn is_unreserved_path_byte(byte : Byte) -> Bool {
-  (byte >= b'A' && byte <= b'Z') ||
-  (byte >= b'a' && byte <= b'z') ||
-  (byte >= b'0' && byte <= b'9') ||
-  byte == b'-' ||
-  byte == b'.' ||
-  byte == b'_' ||
-  byte == b'~'
-}
-
-///|
-fn percent_encode_hex_digit(value : Byte) -> Char {
-  if value < 10 {
-    (value.to_int() + '0'.to_int()).unsafe_to_char()
-  } else {
-    (value.to_int() - 10 + 'A'.to_int()).unsafe_to_char()
-  }
-}
-
-///|
-fn percent_encode_path_component(component : String) -> String {
-  let bytes = @utf8.encode(component).to_array()
-  let builder = StringBuilder::new(size_hint=bytes.length() * 3)
-  for byte in bytes {
-    if is_unreserved_path_byte(byte) {
-      builder.write_char(byte.to_int().unsafe_to_char())
-    } else {
-      builder.write_char('%')
-      builder.write_char(percent_encode_hex_digit(byte / 16))
-      builder.write_char(percent_encode_hex_digit(byte % 16))
-    }
-  }
-  builder.to_string()
 }
 
 ///|
@@ -83,11 +83,13 @@ fn github_contents_url(
 ) -> Result[String, (Int, String)] {
   try {
     let url = @url.Url::parse("https://api.github.com")
-    let enc_owner = percent_encode_path_component(owner)
-    let enc_repo = percent_encode_path_component(repo)
+    let enc_owner = @cli.percent_encode_path_component(owner)
+    let enc_repo = @cli.percent_encode_path_component(repo)
     let enc_filename = filename
       .split("/")
-      .map(fn(segment) { percent_encode_path_component(segment.to_string()) })
+      .map(fn(segment) {
+        @cli.percent_encode_path_component(segment.to_string())
+      })
       .to_array()
       .join("/")
     url.set_pathname("/repos/\{enc_owner}/\{enc_repo}/contents/\{enc_filename}")
@@ -97,6 +99,22 @@ fn github_contents_url(
     Ok(url.to_string())
   } catch {
     _ => Err((0, "failed to build GitHub contents URL for \{filename}"))
+  }
+}
+
+///|
+fn github_repo_url(
+  owner : String,
+  repo : String,
+) -> Result[String, (Int, String)] {
+  try {
+    let url = @url.Url::parse("https://api.github.com")
+    let enc_owner = @cli.percent_encode_path_component(owner)
+    let enc_repo = @cli.percent_encode_path_component(repo)
+    url.set_pathname("/repos/\{enc_owner}/\{enc_repo}")
+    Ok(url.to_string())
+  } catch {
+    _ => Err((0, "failed to build GitHub repository URL for \{owner}/\{repo}"))
   }
 }
 
@@ -170,6 +188,74 @@ fn fetch_contents(
 }
 
 ///|
+fn fetch_default_branch(
+  owner : String,
+  repo : String,
+) -> Result[String, (Int, String)] {
+  let url = match github_repo_url(owner, repo) {
+    Ok(url) => url
+    Err(err) => return Err(err)
+  }
+  let mut result : Result[String, (Int, String)] = Err(
+    (0, "request was not executed"),
+  )
+  @async.run_async_main(() => {
+    let headers = {
+      "User-Agent": @papion.cli_user_agent(),
+      "Accept": "application/vnd.github+json",
+    }
+    if github_token() is Some(token) {
+      headers["Authorization"] = "Bearer \{token}"
+    }
+    let request : Result[String, (Int, String)] = try {
+      let branch = @async.retry(
+        @async.ExponentialDelay(initial=1000, factor=2.0, maximum=10000),
+        max_retry=3,
+        fatal_error=fn(err) {
+          match err {
+            HttpError((code, _)) =>
+              code == 0 || (code >= 400 && code < 500 && code != 429)
+            _ => false
+          }
+        },
+        () => {
+          let pair = @async.with_timeout(30000, () => @http.get(url, headers~))
+          let (response, body) = pair
+          if response.code == 200 {
+            match extract_default_branch_field(body.text(), owner, repo) {
+              Ok(branch) => branch
+              Err(err) => raise HttpError(err)
+            }
+          } else {
+            raise HttpError(
+              (
+                response.code,
+                "failed to fetch repository metadata for \{owner}/\{repo} (\{response.code} \{response.reason})",
+              ),
+            )
+          }
+        },
+      )
+      Ok(branch)
+    } catch {
+      HttpError(err) => Err(err)
+      err =>
+        Err(
+          (
+            0,
+            "failed to fetch repository metadata for \{owner}/\{repo}: \{err}",
+          ),
+        )
+    }
+    match request {
+      Ok(branch) => result = Ok(branch)
+      Err(err) => result = Err(err)
+    }
+  })
+  result
+}
+
+///|
 fn normalize_action_path(path : String?) -> String {
   match path {
     None => ""
@@ -185,26 +271,121 @@ fn normalize_action_path(path : String?) -> String {
 }
 
 ///|
-pub fn fetch_action_yml(
+fn tree_ref_fallbacks(
+  git_ref : String,
+  path : String?,
+) -> Array[(String, String?)] {
+  let fallbacks : Array[(String, String?)] = []
+  let path_value = match path {
+    Some(path_value) => path_value
+    None => return fallbacks
+  }
+  let trimmed_path = path_value.trim(chars="/")
+  if trimmed_path.is_empty() {
+    return fallbacks
+  }
+  let segments : Array[String] = []
+  for segment in trimmed_path.split("/") {
+    let segment = segment.to_string()
+    if !segment.is_empty() {
+      segments.push(segment)
+    }
+  }
+  if segments.is_empty() {
+    return fallbacks
+  }
+  let mut candidate_ref = git_ref
+  let mut i = 0
+  while i < segments.length() {
+    candidate_ref = candidate_ref + "/" + segments[i]
+    let remaining_path = if i + 1 < segments.length() {
+      Some(segments[i + 1:].join("/"))
+    } else {
+      None
+    }
+    fallbacks.push((candidate_ref, remaining_path))
+    i += 1
+  }
+  fallbacks
+}
+
+///|
+fn try_fetch_action_yml(
   owner : String,
   repo : String,
   git_ref : String,
   path : String?,
-) -> Result[String, String] {
+) -> Result[Bytes, (Int, String)] {
   let prefix = normalize_action_path(path)
-  let bytes = match
-    fetch_contents(owner, repo, git_ref, "\{prefix}action.yml") {
-    Ok(bytes) => bytes
+  match fetch_contents(owner, repo, git_ref, "\{prefix}action.yml") {
+    Ok(bytes) => Ok(bytes)
     Err((404, _)) =>
-      match fetch_contents(owner, repo, git_ref, "\{prefix}action.yaml") {
-        Ok(bytes) => bytes
+      fetch_contents(owner, repo, git_ref, "\{prefix}action.yaml")
+    Err(err) => Err(err)
+  }
+}
+
+///|
+fn fetch_action_yml_with_fallback(
+  owner : String,
+  repo : String,
+  git_ref : String,
+  path : String?,
+  allow_ref_fallback : Bool,
+) -> Result[(Bytes, String), (Int, String)] {
+  match try_fetch_action_yml(owner, repo, git_ref, path) {
+    Ok(bytes) => Ok((bytes, git_ref))
+    Err((404, message)) => {
+      if !allow_ref_fallback {
+        return Err((404, message))
+      }
+      let fallbacks = tree_ref_fallbacks(git_ref, path)
+      // Cap fallback attempts to bound worst-case GitHub API requests.
+      let fallback_limit = if fallbacks.length() < 2 {
+        fallbacks.length()
+      } else {
+        2
+      }
+      for i = 0; i < fallback_limit; i = i + 1 {
+        let (fallback_ref, fallback_path) = fallbacks[i]
+        match try_fetch_action_yml(owner, repo, fallback_ref, fallback_path) {
+          Ok(bytes) => return Ok((bytes, fallback_ref))
+          Err((404, _)) => ()
+          Err(err) => return Err(err)
+        }
+      }
+      Err((404, message))
+    }
+    Err(err) => Err(err)
+  }
+}
+
+///|
+pub fn fetch_action_yml(
+  owner : String,
+  repo : String,
+  git_ref : String?,
+  path : String?,
+  allow_ref_fallback : Bool,
+) -> Result[(String, String), String] {
+  let requested_git_ref = match git_ref {
+    Some(git_ref) => git_ref
+    None =>
+      match fetch_default_branch(owner, repo) {
+        Ok(branch) => branch
         Err((_, err)) => return Err(err)
       }
+  }
+  let (bytes, resolved_git_ref) = match
+    fetch_action_yml_with_fallback(
+      owner, repo, requested_git_ref, path, allow_ref_fallback,
+    ) {
+    Ok(result) => result
     Err((_, err)) => return Err(err)
   }
   let action_yml = try? @utf8.decode(bytes)
   match action_yml {
-    Ok(action_yml) => Ok(action_yml)
+    Ok(action_yml) => Ok((action_yml, resolved_git_ref))
     Err(_) => Err("GitHub action file is not valid UTF-8")
   }
 }

--- a/core/native/native_wbtest.mbt
+++ b/core/native/native_wbtest.mbt
@@ -39,30 +39,30 @@ test "load_config normalizes TOML patterns via shared policy helper" {
 
 ///|
 test "percent_encode_path_component: alphanumeric passthrough" {
-  assert_eq(percent_encode_path_component("actions"), "actions")
+  assert_eq(@cli.percent_encode_path_component("actions"), "actions")
 }
 
 ///|
 test "percent_encode_path_component: unreserved chars passthrough" {
   assert_eq(
-    percent_encode_path_component("my.repo_name-v1~0"),
+    @cli.percent_encode_path_component("my.repo_name-v1~0"),
     "my.repo_name-v1~0",
   )
 }
 
 ///|
 test "percent_encode_path_component: slash encoded" {
-  assert_eq(percent_encode_path_component("a/b"), "a%2Fb")
+  assert_eq(@cli.percent_encode_path_component("a/b"), "a%2Fb")
 }
 
 ///|
 test "percent_encode_path_component: space encoded" {
-  assert_eq(percent_encode_path_component("hello world"), "hello%20world")
+  assert_eq(@cli.percent_encode_path_component("hello world"), "hello%20world")
 }
 
 ///|
 test "percent_encode_path_component: unicode encoded" {
-  assert_eq(percent_encode_path_component("café"), "caf%C3%A9")
+  assert_eq(@cli.percent_encode_path_component("café"), "caf%C3%A9")
 }
 
 ///|
@@ -90,12 +90,80 @@ test "github_contents_url encodes owner repo and path segments" {
 }
 
 ///|
+test "github_repo_url encodes owner and repo path segments" {
+  let url = match github_repo_url("maru/loop", "pa pion") {
+    Ok(url) => url
+    Err(err) => fail(err.1)
+  }
+  assert_eq(url, "https://api.github.com/repos/maru%2Floop/pa%20pion")
+}
+
+///|
+test "extract_default_branch_field returns branch when default_branch is string" {
+  assert_eq(
+    extract_default_branch_field(
+      "{\"default_branch\":\"main\"}", "octocat", "hello-world",
+    ),
+    Ok("main"),
+  )
+}
+
+///|
+test "extract_default_branch_field errors when default_branch missing" {
+  assert_eq(
+    extract_default_branch_field(
+      "{\"name\":\"hello-world\"}", "octocat", "hello-world",
+    ),
+    Err(
+      (
+        0, "GitHub repository response for octocat/hello-world did not contain a default_branch field",
+      ),
+    ),
+  )
+}
+
+///|
+test "extract_default_branch_field errors when default_branch is not string" {
+  assert_eq(
+    extract_default_branch_field(
+      "{\"default_branch\":123}", "octocat", "hello-world",
+    ),
+    Err(
+      (
+        0, "GitHub repository response for octocat/hello-world did not contain a string default_branch field",
+      ),
+    ),
+  )
+}
+
+///|
+test "tree_ref_fallbacks shifts path segments into ref" {
+  assert_eq(tree_ref_fallbacks("feature", Some("foo/subdir")), [
+    ("feature/foo", Some("subdir")),
+    ("feature/foo/subdir", None),
+  ])
+}
+
+///|
+test "tree_ref_fallbacks handles single path segment" {
+  assert_eq(tree_ref_fallbacks("release", Some("v1")), [("release/v1", None)])
+}
+
+///|
+test "tree_ref_fallbacks trims slashes and skips empty segments" {
+  assert_eq(tree_ref_fallbacks("release", Some("/v1//subdir/")), [
+    ("release/v1", Some("subdir")),
+    ("release/v1/subdir", None),
+  ])
+}
+
+///|
 test "run config error fires before fetch" {
   let mut fetch_called = false
   let result = @cli.run_with_host(
     ["run", "actions/checkout@v4", "--config", "cli/testdata/missing.toml"],
     load_config,
-    fn(_owner, _repo, _git_ref, _path) {
+    fn(_owner, _repo, _git_ref, _path, _allow_ref_fallback) {
       fetch_called = true
       Err("fetch_action_yml should not be called before config loading")
     },
@@ -118,9 +186,9 @@ test "run parse_args error on --config propagates before fetch" {
       load_config_called = true
       Ok(@papion.Policy::default())
     },
-    fn(_owner, _repo, _git_ref, _path) {
+    fn(_owner, _repo, _git_ref, _path, _allow_ref_fallback) {
       fetch_called = true
-      Ok("")
+      Ok(("", "unused"))
     },
   )
   assert_eq(result, Err(@cli.ArgError("missing value for --config")))

--- a/core/native/pkg.generated.mbti
+++ b/core/native/pkg.generated.mbti
@@ -6,7 +6,7 @@ import {
 }
 
 // Values
-pub fn fetch_action_yml(String, String, String, String?) -> Result[String, String]
+pub fn fetch_action_yml(String, String, String?, String?, Bool) -> Result[(String, String), String]
 
 pub fn load_config(String?) -> Result[@papion.Policy, String]
 

--- a/core/wasm/github.mbt
+++ b/core/wasm/github.mbt
@@ -2,8 +2,9 @@
 pub fn fetch_action_yml(
   _owner : String,
   _repo : String,
-  _git_ref : String,
+  _git_ref : String?,
   _path : String?,
-) -> Result[String, String] {
+  _allow_ref_fallback : Bool,
+) -> Result[(String, String), String] {
   Err("GitHub action fetch is not available on WASM targets")
 }

--- a/core/wasm/pkg.generated.mbti
+++ b/core/wasm/pkg.generated.mbti
@@ -7,7 +7,7 @@ import {
 }
 
 // Values
-pub fn fetch_action_yml(String, String, String, String?) -> Result[String, String]
+pub fn fetch_action_yml(String, String, String?, String?, Bool) -> Result[(String, String), String]
 
 pub fn load_config(String?) -> Result[@papion.Policy, String]
 

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -505,6 +505,7 @@ Adopt the fourth option — fetch only the single file via the GitHub Contents A
 
 * `GET https://api.github.com/repos/{owner}/{repo}/contents/{path}?ref={git_ref}` returns JSON with a base64-encoded `content` field
 * Try `action.yml` first, fall back to `action.yaml`
+* For ambiguous GitHub `/tree/<ref>/<path>` URLs in the native CLI, try at most two ref/path fallback rewrites before returning the original 404
 * Decode base64 in pure MoonBit — no tar extraction needed at all
 * Use `moonbitlang/async/http` for HTTPS — no `libarchive`, no extra build-time development headers, and only the runtime libraries required by the generated native binary
 * `moonbitlang/async/tls` loads OpenSSL via `dlopen()` at runtime (typically available on GitHub-hosted runners and most desktop/server macOS/Linux environments, but not guaranteed in minimal or distroless images; no dev headers required)
@@ -518,6 +519,8 @@ Adopt the fourth option — fetch only the single file via the GitHub Contents A
 * `moonbitlang/async/http` + `dlopen()` TLS eliminates all C library build-time dependencies
 * Pure MoonBit base64 decode is trivial and already available in `moonbitlang/core/encoding`
 * Fewer moving parts: one HTTP GET replaces tarball download + decompression + tar parsing
+* Capping ambiguous tree-ref fallback rewrites at `2` bounds worst-case native fetch traffic to 6 total GitHub Contents requests (`action.yml` + `action.yaml` for the initial parse, then for up to two fallback candidates)
+* The cap of `2` still covers the practical slash-containing ref shapes we expect for now; deeper refs are a deliberate follow-up tradeoff rather than unbounded retry behavior
 
 ### Consequence
 
@@ -526,6 +529,7 @@ Adopt the fourth option — fetch only the single file via the GitHub Contents A
 * `core/native/fileio.mbt` provides `fopen`/`fread` file I/O for config loading via libc — always available, no extra headers
 * For browser WASM / edge JS targets, the host-side fetch/config boundary now lives in `core/wasm/github.mbt` and `core/wasm/config.mbt`
 * The GitHub Contents API requires a valid `ref` (branch, tag, or full SHA) — all are supported
+* Very deep slash-containing refs in pasted GitHub tree URLs may still fail native fallback resolution today; widening the cap remains an explicit future adjustment if real usage justifies the extra requests
 * The CLI host layer is split into target-aware packages so target-specific dependencies are represented structurally instead of through keepalive references.
 
 ### CLI package boundaries


### PR DESCRIPTION
## Summary
- allow `papion run` targets to omit `@ref` for bare `owner/repo` and GitHub repository URLs
- parse GitHub tree URLs and add native fallback resolution for ambiguous tree refs that may include path segments
- make host fetch paths accept optional refs and update CLI/native formatting and tests accordingly

## Testing
- moon test --deny-warn
- moon test --target native --deny-warn