### PR TITLE
feat(native): resolve ambiguous tree URL refs via GitHub matching-refs API

### DIFF
--- a/core/native/github.mbt
+++ b/core/native/github.mbt
@@ -67,6 +67,69 @@ fn extract_default_branch_field(
 }
 
 ///|
+fn extract_matching_refs_field(
+  body : String,
+  owner : String,
+  repo : String,
+  ref_type : String,
+) -> Result[Array[String], (Int, String)] {
+  let json = try? @json.parse(body)
+  let json = match json {
+    Ok(json) => json
+    Err(err) =>
+      return Err(
+        (
+          0,
+          "failed to parse GitHub matching refs response for \{owner}/\{repo}: \{err}",
+        ),
+      )
+  }
+  let expected_prefix = "refs/\{ref_type}/"
+  match json {
+    Array(arr) => {
+      let refs : Array[String] = []
+      for item in arr {
+        match item {
+          { "ref": String(ref_name), .. } => {
+            if !ref_name.has_prefix(expected_prefix) {
+              return Err(
+                (
+                  0,
+                  "GitHub matching refs response for \{owner}/\{repo} contained ref outside refs/\{ref_type}/: \{ref_name}",
+                ),
+              )
+            }
+            refs.push(ref_name[expected_prefix.length():].to_string())
+          }
+          { "ref": _, .. } =>
+            return Err(
+              (
+                0,
+                "GitHub matching refs response for \{owner}/\{repo} did not contain a string ref field",
+              ),
+            )
+          _ =>
+            return Err(
+              (
+                0,
+                "GitHub matching refs response for \{owner}/\{repo} did not contain a ref field",
+              ),
+            )
+        }
+      }
+      Ok(refs)
+    }
+    _ =>
+      Err(
+        (
+          0,
+          "GitHub matching refs response for \{owner}/\{repo} was not an array",
+        ),
+      )
+  }
+}
+
+///|
 fn github_token() -> String? {
   match @env.get_env_var("GITHUB_TOKEN") {
     Some("") => None
@@ -115,6 +178,35 @@ fn github_repo_url(
     Ok(url.to_string())
   } catch {
     _ => Err((0, "failed to build GitHub repository URL for \{owner}/\{repo}"))
+  }
+}
+
+///|
+fn github_matching_refs_url(
+  owner : String,
+  repo : String,
+  ref_type : String,
+  prefix : String,
+) -> Result[String, (Int, String)] {
+  try {
+    let url = @url.Url::parse("https://api.github.com")
+    let enc_owner = @cli.percent_encode_path_component(owner)
+    let enc_repo = @cli.percent_encode_path_component(repo)
+    let enc_ref_type = @cli.percent_encode_path_component(ref_type)
+    let enc_prefix = prefix
+      .split("/")
+      .map(fn(segment) {
+        @cli.percent_encode_path_component(segment.to_string())
+      })
+      .to_array()
+      .join("/")
+    url.set_pathname(
+      "/repos/\{enc_owner}/\{enc_repo}/git/matching-refs/\{enc_ref_type}/\{enc_prefix}",
+    )
+    Ok(url.to_string())
+  } catch {
+    _ =>
+      Err((0, "failed to build GitHub matching refs URL for \{owner}/\{repo}"))
   }
 }
 
@@ -256,6 +348,72 @@ fn fetch_default_branch(
 }
 
 ///|
+fn fetch_matching_refs(
+  owner : String,
+  repo : String,
+  ref_type : String,
+  prefix : String,
+) -> Result[Array[String], (Int, String)] {
+  let url = match github_matching_refs_url(owner, repo, ref_type, prefix) {
+    Ok(url) => url
+    Err(err) => return Err(err)
+  }
+  let mut result : Result[Array[String], (Int, String)] = Err(
+    (0, "request was not executed"),
+  )
+  @async.run_async_main(() => {
+    let headers = {
+      "User-Agent": @papion.cli_user_agent(),
+      "Accept": "application/vnd.github+json",
+    }
+    if github_token() is Some(token) {
+      headers["Authorization"] = "Bearer \{token}"
+    }
+    let request : Result[Array[String], (Int, String)] = try {
+      let refs = @async.retry(
+        @async.ExponentialDelay(initial=1000, factor=2.0, maximum=10000),
+        max_retry=3,
+        fatal_error=fn(err) {
+          match err {
+            HttpError((code, _)) =>
+              code == 0 || (code >= 400 && code < 500 && code != 429)
+            _ => false
+          }
+        },
+        () => {
+          let pair = @async.with_timeout(30000, () => @http.get(url, headers~))
+          let (response, body) = pair
+          if response.code == 200 {
+            match
+              extract_matching_refs_field(body.text(), owner, repo, ref_type) {
+              Ok(refs) => refs
+              Err(err) => raise HttpError(err)
+            }
+          } else {
+            raise HttpError(
+              (
+                response.code,
+                "failed to fetch matching refs for \{owner}/\{repo} (\{response.code} \{response.reason})",
+              ),
+            )
+          }
+        },
+      )
+      Ok(refs)
+    } catch {
+      HttpError(err) => Err(err)
+      err =>
+        Err((0, "failed to fetch matching refs for \{owner}/\{repo}: \{err}"))
+    }
+    match request {
+      Ok(refs) => result = Ok(refs)
+      Err(err) => result = Err(err)
+    }
+  })
+  result
+}
+
+///|
 fn normalize_action_path(path : String?) -> String {
   match path {
     None => ""
@@ -271,42 +429,70 @@ fn normalize_action_path(path : String?) -> String {
 }
 
 ///|
-fn tree_ref_fallbacks(
-  git_ref : String,
+fn resolve_matching_ref(
+  owner : String,
+  repo : String,
+  ref_prefix : String,
   path : String?,
-) -> Array[(String, String?)] {
-  let fallbacks : Array[(String, String?)] = []
-  let path_value = match path {
-    Some(path_value) => path_value
-    None => return fallbacks
+) -> Result[(String, String?), (Int, String)] {
+  let head_refs = match fetch_matching_refs(owner, repo, "heads", ref_prefix) {
+    Ok(refs) => refs
+    Err(_) => []
   }
-  let trimmed_path = path_value.trim(chars="/")
-  if trimmed_path.is_empty() {
-    return fallbacks
+  let tag_refs = if head_refs.is_empty() {
+    match fetch_matching_refs(owner, repo, "tags", ref_prefix) {
+      Ok(refs) => refs
+      Err(err) => {
+        if head_refs.is_empty() {
+          return Err(err)
+        }
+        []
+      }
+    }
+  } else {
+    []
   }
-  let segments : Array[String] = []
-  for segment in trimmed_path.split("/") {
-    let segment = segment.to_string()
-    if !segment.is_empty() {
-      segments.push(segment)
+  let candidates : Array[String] = []
+  for ref_name in head_refs {
+    candidates.push(ref_name)
+  }
+  for ref_name in tag_refs {
+    candidates.push(ref_name)
+  }
+  let full_path = match path {
+    Some(path_value) if !path_value.is_empty() => "\{ref_prefix}/\{path_value}"
+    _ => ref_prefix
+  }
+  let mut best_ref : String? = None
+  for candidate_ref in candidates {
+    if full_path == candidate_ref || full_path.has_prefix(candidate_ref + "/") {
+      match best_ref {
+        Some(current) if current.length() >= candidate_ref.length() => ()
+        _ => best_ref = Some(candidate_ref)
+      }
     }
   }
-  if segments.is_empty() {
-    return fallbacks
+  let resolved_ref = match best_ref {
+    Some(ref_name) => ref_name
+    None =>
+      return Err(
+        (
+          404,
+          "no matching Git refs found for \{owner}/\{repo} with prefix \{ref_prefix}",
+        ),
+      )
   }
-  let mut candidate_ref = git_ref
-  let mut i = 0
-  while i < segments.length() {
-    candidate_ref = candidate_ref + "/" + segments[i]
-    let remaining_path = if i + 1 < segments.length() {
-      Some(segments[i + 1:].join("/"))
-    } else {
+  let remaining = if full_path.length() == resolved_ref.length() {
+    None
+  } else {
+    let suffix = full_path[resolved_ref.length() + 1:].to_string()
+    if suffix.is_empty() {
       None
+    } else {
+      Some(suffix)
     }
-    fallbacks.push((candidate_ref, remaining_path))
-    i += 1
   }
-  fallbacks
+  Ok((resolved_ref, remaining))
 }
 
 ///|
@@ -336,25 +522,17 @@ fn fetch_action_yml_with_fallback(
   match try_fetch_action_yml(owner, repo, git_ref, path) {
     Ok(bytes) => Ok((bytes, git_ref))
     Err((404, message)) => {
-      if !allow_ref_fallback {
+      if !allow_ref_fallback || path is None {
         return Err((404, message))
       }
-      let fallbacks = tree_ref_fallbacks(git_ref, path)
-      // Cap fallback attempts to bound worst-case GitHub API requests.
-      let fallback_limit = if fallbacks.length() < 2 {
-        fallbacks.length()
-      } else {
-        2
+      match resolve_matching_ref(owner, repo, git_ref, path) {
+        Ok((resolved_ref, resolved_path)) =>
+          match try_fetch_action_yml(owner, repo, resolved_ref, resolved_path) {
+            Ok(bytes) => Ok((bytes, resolved_ref))
+            Err(err) => Err(err)
+          }
+        Err(_) => Err((404, message))
       }
-      for i = 0; i < fallback_limit; i = i + 1 {
-        let (fallback_ref, fallback_path) = fallbacks[i]
-        match try_fetch_action_yml(owner, repo, fallback_ref, fallback_path) {
-          Ok(bytes) => return Ok((bytes, fallback_ref))
-          Err((404, _)) => ()
-          Err(err) => return Err(err)
-        }
-      }
-      Err((404, message))
     }
     Err(err) => Err(err)
   }

--- a/core/native/github.mbt
+++ b/core/native/github.mbt
@@ -203,6 +203,9 @@ fn github_matching_refs_url(
     url.set_pathname(
       "/repos/\{enc_owner}/\{enc_repo}/git/matching-refs/\{enc_ref_type}/\{enc_prefix}",
     )
+    let params = @url.UrlSearchParams::new()
+    params.set("per_page", "100")
+    url.set_search_params(params)
     Ok(url.to_string())
   } catch {
     _ =>
@@ -438,9 +441,16 @@ fn select_best_matching_ref(
     Some(path_value) if !path_value.is_empty() => "\{ref_prefix}/\{path_value}"
     _ => ref_prefix
   }
+  let normalized_full_path = full_path
+    .split("/")
+    .filter(fn(segment) { !segment.to_string().is_empty() })
+    .map(fn(segment) { segment.to_string() })
+    .to_array()
+    .join("/")
   let mut best_ref : String? = None
   for candidate_ref in candidates {
-    if full_path == candidate_ref || full_path.has_prefix(candidate_ref + "/") {
+    if normalized_full_path == candidate_ref ||
+      normalized_full_path.has_prefix(candidate_ref + "/") {
       match best_ref {
         Some(current) if current.length() >= candidate_ref.length() => ()
         _ => best_ref = Some(candidate_ref)
@@ -451,10 +461,10 @@ fn select_best_matching_ref(
     Some(ref_name) => ref_name
     None => return Err("no matching Git refs found")
   }
-  let remaining = if full_path.length() == resolved_ref.length() {
+  let remaining = if normalized_full_path.length() == resolved_ref.length() {
     None
   } else {
-    let suffix = full_path[resolved_ref.length() + 1:].to_string()
+    let suffix = normalized_full_path[resolved_ref.length() + 1:].to_string()
     if suffix.is_empty() {
       None
     } else {

--- a/core/native/github.mbt
+++ b/core/native/github.mbt
@@ -429,36 +429,11 @@ fn normalize_action_path(path : String?) -> String {
 }
 
 ///|
-fn resolve_matching_ref(
-  owner : String,
-  repo : String,
+fn select_best_matching_ref(
+  candidates : Array[String],
   ref_prefix : String,
   path : String?,
-) -> Result[(String, String?), (Int, String)] {
-  let head_refs = match fetch_matching_refs(owner, repo, "heads", ref_prefix) {
-    Ok(refs) => refs
-    Err(_) => []
-  }
-  let tag_refs = if head_refs.is_empty() {
-    match fetch_matching_refs(owner, repo, "tags", ref_prefix) {
-      Ok(refs) => refs
-      Err(err) => {
-        if head_refs.is_empty() {
-          return Err(err)
-        }
-        []
-      }
-    }
-  } else {
-    []
-  }
-  let candidates : Array[String] = []
-  for ref_name in head_refs {
-    candidates.push(ref_name)
-  }
-  for ref_name in tag_refs {
-    candidates.push(ref_name)
-  }
+) -> Result[(String, String?), String] {
   let full_path = match path {
     Some(path_value) if !path_value.is_empty() => "\{ref_prefix}/\{path_value}"
     _ => ref_prefix
@@ -474,13 +449,7 @@ fn resolve_matching_ref(
   }
   let resolved_ref = match best_ref {
     Some(ref_name) => ref_name
-    None =>
-      return Err(
-        (
-          404,
-          "no matching Git refs found for \{owner}/\{repo} with prefix \{ref_prefix}",
-        ),
-      )
+    None => return Err("no matching Git refs found")
   }
   let remaining = if full_path.length() == resolved_ref.length() {
     None
@@ -493,6 +462,42 @@ fn resolve_matching_ref(
     }
   }
   Ok((resolved_ref, remaining))
+}
+
+///|
+fn resolve_matching_ref(
+  owner : String,
+  repo : String,
+  ref_prefix : String,
+  path : String?,
+) -> Result[(String, String?), (Int, String)] {
+  let head_refs = match fetch_matching_refs(owner, repo, "heads", ref_prefix) {
+    Ok(refs) => refs
+    Err((404, _)) => []
+    Err(err) => return Err(err)
+  }
+  let tag_refs = match fetch_matching_refs(owner, repo, "tags", ref_prefix) {
+    Ok(refs) => refs
+    Err((404, _)) => []
+    Err(err) => return Err(err)
+  }
+  let candidates : Array[String] = []
+  for ref_name in head_refs {
+    candidates.push(ref_name)
+  }
+  for ref_name in tag_refs {
+    candidates.push(ref_name)
+  }
+  match select_best_matching_ref(candidates, ref_prefix, path) {
+    Ok(result) => Ok(result)
+    Err(_) =>
+      return Err(
+        (
+          404,
+          "no matching Git refs found for \{owner}/\{repo} with prefix \{ref_prefix}",
+        ),
+      )
+  }
 }
 
 ///|
@@ -531,7 +536,8 @@ fn fetch_action_yml_with_fallback(
             Ok(bytes) => Ok((bytes, resolved_ref))
             Err(err) => Err(err)
           }
-        Err(_) => Err((404, message))
+        Err((404, _)) => Err((404, message))
+        Err(err) => Err(err)
       }
     }
     Err(err) => Err(err)

--- a/core/native/native_wbtest.mbt
+++ b/core/native/native_wbtest.mbt
@@ -90,12 +90,90 @@ test "github_contents_url encodes owner repo and path segments" {
 }
 
 ///|
+test "github_matching_refs_url encodes heads path components" {
+  let url = match
+    github_matching_refs_url("maru/loop", "pa pion", "heads", "release/v1") {
+    Ok(url) => url
+    Err(err) => fail(err.1)
+  }
+  assert_eq(
+    url, "https://api.github.com/repos/maru%2Floop/pa%20pion/git/matching-refs/heads/release/v1",
+  )
+}
+
+///|
+test "github_matching_refs_url encodes tags path components" {
+  let url = match
+    github_matching_refs_url("maruloop", "papion", "tags", "v1.0.0/rc 1") {
+    Ok(url) => url
+    Err(err) => fail(err.1)
+  }
+  assert_eq(
+    url, "https://api.github.com/repos/maruloop/papion/git/matching-refs/tags/v1.0.0/rc%201",
+  )
+}
+
+///|
 test "github_repo_url encodes owner and repo path segments" {
   let url = match github_repo_url("maru/loop", "pa pion") {
     Ok(url) => url
     Err(err) => fail(err.1)
   }
   assert_eq(url, "https://api.github.com/repos/maru%2Floop/pa%20pion")
+}
+
+///|
+test "extract_matching_refs_field returns stripped refs" {
+  assert_eq(
+    extract_matching_refs_field(
+      (
+        #|[
+        #|  {"ref":"refs/heads/release","node_id":"1"},
+        #|  {"ref":"refs/heads/release/v1","node_id":"2"}
+        #|]
+      ),
+      "octocat",
+      "hello-world",
+      "heads",
+    ),
+    Ok(["release", "release/v1"]),
+  )
+}
+
+///|
+test "extract_matching_refs_field returns empty array" {
+  assert_eq(
+    extract_matching_refs_field("[]", "octocat", "hello-world", "tags"),
+    Ok([]),
+  )
+}
+
+///|
+test "extract_matching_refs_field errors when ref field missing" {
+  assert_eq(
+    extract_matching_refs_field(
+      "[{\"node_id\":\"1\"}]", "octocat", "hello-world", "heads",
+    ),
+    Err(
+      (
+        0, "GitHub matching refs response for octocat/hello-world did not contain a ref field",
+      ),
+    ),
+  )
+}
+
+///|
+test "extract_matching_refs_field errors when ref field is not string" {
+  assert_eq(
+    extract_matching_refs_field(
+      "[{\"ref\":123}]", "octocat", "hello-world", "heads",
+    ),
+    Err(
+      (
+        0, "GitHub matching refs response for octocat/hello-world did not contain a string ref field",
+      ),
+    ),
+  )
 }
 
 ///|
@@ -134,27 +212,6 @@ test "extract_default_branch_field errors when default_branch is not string" {
       ),
     ),
   )
-}
-
-///|
-test "tree_ref_fallbacks shifts path segments into ref" {
-  assert_eq(tree_ref_fallbacks("feature", Some("foo/subdir")), [
-    ("feature/foo", Some("subdir")),
-    ("feature/foo/subdir", None),
-  ])
-}
-
-///|
-test "tree_ref_fallbacks handles single path segment" {
-  assert_eq(tree_ref_fallbacks("release", Some("v1")), [("release/v1", None)])
-}
-
-///|
-test "tree_ref_fallbacks trims slashes and skips empty segments" {
-  assert_eq(tree_ref_fallbacks("release", Some("/v1//subdir/")), [
-    ("release/v1", Some("subdir")),
-    ("release/v1/subdir", None),
-  ])
 }
 
 ///|

--- a/core/native/native_wbtest.mbt
+++ b/core/native/native_wbtest.mbt
@@ -97,7 +97,7 @@ test "github_matching_refs_url encodes heads path components" {
     Err(err) => fail(err.1)
   }
   assert_eq(
-    url, "https://api.github.com/repos/maru%2Floop/pa%20pion/git/matching-refs/heads/release/v1",
+    url, "https://api.github.com/repos/maru%2Floop/pa%20pion/git/matching-refs/heads/release/v1?per_page=100",
   )
 }
 
@@ -109,7 +109,7 @@ test "github_matching_refs_url encodes tags path components" {
     Err(err) => fail(err.1)
   }
   assert_eq(
-    url, "https://api.github.com/repos/maruloop/papion/git/matching-refs/tags/v1.0.0/rc%201",
+    url, "https://api.github.com/repos/maruloop/papion/git/matching-refs/tags/v1.0.0/rc%201?per_page=100",
   )
 }
 
@@ -245,6 +245,27 @@ test "select_best_matching_ref errors when candidates empty" {
     select_best_matching_ref([], "release", Some("v1/action")),
     Err("no matching Git refs found"),
   )
+}
+
+///|
+test "select_best_matching_ref normalizes leading slash path" {
+  assert_eq(
+    select_best_matching_ref(["release/v1"], "release", Some("/v1/action")),
+    Ok(("release/v1", Some("action"))),
+  )
+}
+
+///|
+test "select_best_matching_ref normalizes double slash path" {
+  assert_eq(
+    select_best_matching_ref(["release/v1"], "release", Some("v1//action")),
+    Ok(("release/v1", Some("action"))),
+  )
+}
+
+///|
+test "select_best_matching_ref normalizes trailing slash path to none" {
+  assert_eq(select_best_matching_ref(["v4"], "v4", Some("/")), Ok(("v4", None)))
 }
 
 ///|

--- a/core/native/native_wbtest.mbt
+++ b/core/native/native_wbtest.mbt
@@ -215,6 +215,39 @@ test "extract_default_branch_field errors when default_branch is not string" {
 }
 
 ///|
+test "select_best_matching_ref returns exact ref with no remaining path" {
+  assert_eq(select_best_matching_ref(["v4"], "v4", None), Ok(("v4", None)))
+}
+
+///|
+test "select_best_matching_ref picks longest matching ref" {
+  assert_eq(
+    select_best_matching_ref(
+      ["release", "release/v1"],
+      "release",
+      Some("v1/action"),
+    ),
+    Ok(("release/v1", Some("action"))),
+  )
+}
+
+///|
+test "select_best_matching_ref errors when no candidate matches" {
+  assert_eq(
+    select_best_matching_ref(["release/v2"], "release", Some("v1/action")),
+    Err("no matching Git refs found"),
+  )
+}
+
+///|
+test "select_best_matching_ref errors when candidates empty" {
+  assert_eq(
+    select_best_matching_ref([], "release", Some("v1/action")),
+    Err("no matching Git refs found"),
+  )
+}
+
+///|
 test "run config error fires before fetch" {
   let mut fetch_called = false
   let result = @cli.run_with_host(


### PR DESCRIPTION
## Summary
- replace tree-ref 404 probing with GitHub `matching-refs` resolution in the native host
- resolve the longest matching branch/tag ref before retrying `action.yml` fetches for ambiguous `/tree/...` URLs
- add whitebox coverage for matching-refs URL construction and JSON parsing helpers

Closes #44

## Testing
- `moon fmt --check`
- `moon test --deny-warn`
- `moon test --target native --deny-warn`
- `moon build --target native`
- `./_build/native/debug/build/native/native.exe run https://github.com/actions/checkout/tree/v4`
- `./_build/native/debug/build/native/native.exe run actions/checkout@v4`