### PR TITLE
feat(rules): allow immutable releases and verify SHAs via API

### DIFF
--- a/core/README.mbt.md
+++ b/core/README.mbt.md
@@ -1,17 +1,20 @@
 # Papion Core
 
-Pure MoonBit engine for scanning GitHub Actions. No I/O, no host imports — all data exchange happens via JSON strings at the WASM boundary.
+Pure MoonBit engine for scanning GitHub Actions. Core logic is portable and environment-agnostic. Host-specific I/O (GitHub API, file system) is injected via callbacks.
 
 ## Packages
 
 | Package | Purpose |
 |---------|---------|
 | `papion` (root) | Core data types shared by all packages |
-| `papion/parser` | Parse action.yml JSON into core types |
+| `papion/parser` | Parse action.yml YAML into core types |
 | `papion/config` | Parse policy configuration JSON, glob matching for allowed/disallowed lists |
-| `papion/rules` | Evaluate policy rules against action references (**this PR**) |
-| `papion/format` | Format scan results as human-readable or JSON output (planned: WS7) |
-| `papion/engine` | Orchestrate a full scan (WASM entry point) (planned: WS5) |
+| `papion/rules` | Evaluate policy rules against action references |
+| `papion/format` | Format scan results as human-readable or JSON output |
+| `papion/engine` | Orchestrate a full scan |
+| `papion/cli` | Target-agnostic argument parsing, orchestration, formatting selection |
+| `papion/native` | Native CLI executable, GitHub API integration, file I/O |
+| `papion/wasm` | WASM/browser-facing stubs and host bindings |
 
 ## Data Model
 
@@ -33,7 +36,7 @@ ActionRef {
 Classifies the type of ref.
 
 ```
-RefKind = Sha | Tag | Branch
+RefKind = Sha | Tag | Branch | ImmutableRelease
 ```
 
 ### ActionYml
@@ -140,6 +143,6 @@ Summary {
 ## Build Targets
 
 ```sh
-moon build --target wasm-gc    # WASM for Go CLI
-moon build --target js         # JS for browser / Cloudflare
+moon build --target native   # Native CLI binary
+moon build --target js       # JS for browser / Cloudflare
 ```

--- a/core/README.mbt.md
+++ b/core/README.mbt.md
@@ -144,5 +144,6 @@ Summary {
 
 ```sh
 moon build --target native   # Native CLI binary
-moon build --target js       # JS for browser / Cloudflare
+moon build --target js       # JS for browser / Cloudflare Workers
+moon build --target wasm-gc  # WASM (GC) for browser embedding
 ```

--- a/core/cli/cli_test.mbt
+++ b/core/cli/cli_test.mbt
@@ -441,6 +441,49 @@ test "run_with_host passes allow_ref_fallback for github tree urls" {
 }
 
 ///|
+test "run_with_host passes custom ref kind resolver into engine" {
+  let mut resolver_called = false
+  let mut resolved_owner = ""
+  let mut resolved_repo = ""
+  let mut resolved_git_ref = ""
+  let result = run_with_host(
+    ["run", "actions/checkout@v4", "--format", "json"],
+    fn(_config_path) { Ok(@papion.Policy::default()) },
+    fn(_owner, _repo, _git_ref, _path, _allow_ref_fallback) {
+      Ok(
+        (
+          (
+            #|name: Composite
+            #|runs:
+            #|  using: composite
+            #|  steps:
+            #|    - uses: actions/checkout@v4
+          ),
+          "v4",
+        ),
+      )
+    },
+    resolve_ref_kind=fn(owner, repo, git_ref) {
+      resolver_called = true
+      resolved_owner = owner
+      resolved_repo = repo
+      resolved_git_ref = git_ref
+      @papion.RefKind::ImmutableRelease
+    },
+  )
+  match result {
+    Ok(outcome) => {
+      assert_eq(resolver_called, true)
+      assert_eq(resolved_owner, "actions")
+      assert_eq(resolved_repo, "checkout")
+      assert_eq(resolved_git_ref, "v4")
+      assert_true(outcome.output.contains("\"findings\":[]"))
+    }
+    Err(err) => fail(err.to_string())
+  }
+}
+
+///|
 test "exit_code_for fail_on fail clean" {
   assert_eq(exit_code_for({ failures: 0, warnings: 0 }, Fail), 0)
 }

--- a/core/cli/moon.pkg
+++ b/core/cli/moon.pkg
@@ -2,6 +2,7 @@ import {
   "maruloop/papion/engine",
   "maruloop/papion/format",
   "maruloop/papion",
+  "maruloop/papion/rules",
   "moonbitlang/core/buffer",
   "moonbitlang/core/encoding/utf8",
 }

--- a/core/cli/pkg.generated.mbti
+++ b/core/cli/pkg.generated.mbti
@@ -15,7 +15,7 @@ pub fn percent_decode_url_path_segment(String) -> Result[String, String]
 
 pub fn percent_encode_path_component(String) -> String
 
-pub fn run_with_host(Array[String], (String?) -> Result[@papion.Policy, String], (String, String, String?, String?, Bool) -> Result[(String, String), String]) -> Result[RunOutcome, CliError]
+pub fn run_with_host(Array[String], (String?) -> Result[@papion.Policy, String], (String, String, String?, String?, Bool) -> Result[(String, String), String], resolve_ref_kind? : (String, String, String) -> @papion.RefKind) -> Result[RunOutcome, CliError]
 
 // Errors
 

--- a/core/cli/run.mbt
+++ b/core/cli/run.mbt
@@ -30,6 +30,13 @@ pub fn run_with_host(
     (String, String),
     String,
   ],
+  resolve_ref_kind? : (String, String, String) -> @papion.RefKind = fn(
+    _owner,
+    _repo,
+    git_ref,
+  ) {
+    @rules.classify_ref(git_ref)
+  },
 ) -> Result[RunOutcome, CliError] {
   let options = match parse_args(args) {
     Ok(options) => options
@@ -55,6 +62,7 @@ pub fn run_with_host(
       { owner: options.owner, repo: options.repo, git_ref: resolved_git_ref },
       action_yml,
       policy,
+      resolve_ref_kind~,
     ) {
     Ok(result) => result
     Err(err) => return Err(RuntimeError(err))

--- a/core/engine/engine.mbt
+++ b/core/engine/engine.mbt
@@ -10,6 +10,13 @@ pub fn scan(
   target : @papion.ScanTarget,
   action_yml_yaml : String,
   policy : @papion.Policy,
+  resolve_ref_kind? : (String, String, String) -> @papion.RefKind = fn(
+    _owner,
+    _repo,
+    git_ref,
+  ) {
+    @rules.classify_ref(git_ref)
+  },
 ) -> Result[@papion.ScanResult, String] {
   let policy = match policy.normalized() {
     Ok(policy) => policy
@@ -22,7 +29,8 @@ pub fn scan(
   let refs = @parser.extract_refs(yml)
   let findings : Array[@papion.Finding] = []
   for ref_ in refs {
-    findings.append(@rules.evaluate(ref_, policy))
+    let ref_kind = resolve_ref_kind(ref_.owner, ref_.repo, ref_.git_ref)
+    findings.append(@rules.evaluate(ref_, ref_kind, policy))
   }
   let failures = findings.iter().filter(fn(f) { f.level == Fail }).count()
   let warnings = findings.iter().filter(fn(f) { f.level == Warn }).count()

--- a/core/engine/engine_test.mbt
+++ b/core/engine/engine_test.mbt
@@ -187,6 +187,46 @@ test "scan result target matches input" {
 }
 
 ///|
+test "scan uses injected ref kind resolver" {
+  let target : @papion.ScanTarget = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "v4",
+  }
+  let yaml_str =
+    #|name: My Action
+    #|runs:
+    #|  using: composite
+    #|  steps:
+    #|    - uses: actions/checkout@v4
+  let mut calls = 0
+  let mut resolved_owner = ""
+  let mut resolved_repo = ""
+  let mut resolved_git_ref = ""
+  let result = scan(target, yaml_str, @papion.Policy::default(), resolve_ref_kind=fn(
+    owner,
+    repo,
+    git_ref,
+  ) {
+    calls = calls + 1
+    resolved_owner = owner
+    resolved_repo = repo
+    resolved_git_ref = git_ref
+    ImmutableRelease
+  })
+  match result {
+    Err(e) => fail("unexpected error: \{e}")
+    Ok(r) => {
+      assert_eq(calls, 1)
+      assert_eq(resolved_owner, "actions")
+      assert_eq(resolved_repo, "checkout")
+      assert_eq(resolved_git_ref, "v4")
+      assert_eq(r.findings, [])
+    }
+  }
+}
+
+///|
 test "scan normalizes policy patterns before evaluation" {
   let target : @papion.ScanTarget = {
     owner: "actions",

--- a/core/engine/pkg.generated.mbti
+++ b/core/engine/pkg.generated.mbti
@@ -6,7 +6,7 @@ import {
 }
 
 // Values
-pub fn scan(@papion.ScanTarget, String, @papion.Policy) -> Result[@papion.ScanResult, String]
+pub fn scan(@papion.ScanTarget, String, @papion.Policy, resolve_ref_kind? : (String, String, String) -> @papion.RefKind) -> Result[@papion.ScanResult, String]
 
 // Errors
 

--- a/core/native/github.mbt
+++ b/core/native/github.mbt
@@ -796,11 +796,9 @@ pub fn resolve_ref_kind_via_api(
   repo : String,
   git_ref : String,
 ) -> @papion.RefKind {
-  if @rules.classify_ref(git_ref) == Sha {
-    match fetch_commit_exists(owner, repo, git_ref) {
-      Ok(true) => return Sha
-      _ => return Branch
-    }
+  match fetch_commit_exists(owner, repo, git_ref) {
+    Ok(true) => return Sha
+    _ => ()
   }
   match fetch_release_by_tag(owner, repo, git_ref) {
     Ok(true) => ImmutableRelease

--- a/core/native/github.mbt
+++ b/core/native/github.mbt
@@ -67,6 +67,38 @@ fn extract_default_branch_field(
 }
 
 ///|
+fn extract_release_immutable_field(
+  body : String,
+  owner : String,
+  repo : String,
+  tag : String,
+) -> Result[Bool, (Int, String)] {
+  let json = try? @json.parse(body)
+  let json = match json {
+    Ok(json) => json
+    Err(err) =>
+      return Err(
+        (
+          0,
+          "failed to parse GitHub release response for \{owner}/\{repo}@\{tag}: \{err}",
+        ),
+      )
+  }
+  match json {
+    { "immutable": true, .. } => Ok(true)
+    { "immutable": false, .. } => Ok(false)
+    { "immutable": _, .. } =>
+      Err(
+        (
+          0,
+          "GitHub release response for \{owner}/\{repo}@\{tag} did not contain a boolean immutable field",
+        ),
+      )
+    _ => Ok(false)
+  }
+}
+
+///|
 fn extract_matching_refs_field(
   body : String,
   owner : String,
@@ -178,6 +210,50 @@ fn github_repo_url(
     Ok(url.to_string())
   } catch {
     _ => Err((0, "failed to build GitHub repository URL for \{owner}/\{repo}"))
+  }
+}
+
+///|
+fn github_release_by_tag_url(
+  owner : String,
+  repo : String,
+  tag : String,
+) -> Result[String, (Int, String)] {
+  try {
+    let url = @url.Url::parse("https://api.github.com")
+    let enc_owner = @cli.percent_encode_path_component(owner)
+    let enc_repo = @cli.percent_encode_path_component(repo)
+    let enc_tag = tag
+      .split("/")
+      .map(fn(segment) {
+        @cli.percent_encode_path_component(segment.to_string())
+      })
+      .to_array()
+      .join("/")
+    url.set_pathname("/repos/\{enc_owner}/\{enc_repo}/releases/tags/\{enc_tag}")
+    Ok(url.to_string())
+  } catch {
+    _ =>
+      Err((0, "failed to build GitHub release URL for \{owner}/\{repo}@\{tag}"))
+  }
+}
+
+///|
+fn github_commit_url(
+  owner : String,
+  repo : String,
+  sha : String,
+) -> Result[String, (Int, String)] {
+  try {
+    let url = @url.Url::parse("https://api.github.com")
+    let enc_owner = @cli.percent_encode_path_component(owner)
+    let enc_repo = @cli.percent_encode_path_component(repo)
+    let enc_sha = @cli.percent_encode_path_component(sha)
+    url.set_pathname("/repos/\{enc_owner}/\{enc_repo}/git/commits/\{enc_sha}")
+    Ok(url.to_string())
+  } catch {
+    _ =>
+      Err((0, "failed to build GitHub commit URL for \{owner}/\{repo}@\{sha}"))
   }
 }
 
@@ -344,6 +420,142 @@ fn fetch_default_branch(
     }
     match request {
       Ok(branch) => result = Ok(branch)
+      Err(err) => result = Err(err)
+    }
+  })
+  result
+}
+
+///|
+fn fetch_release_by_tag(
+  owner : String,
+  repo : String,
+  tag : String,
+) -> Result[Bool, (Int, String)] {
+  let url = match github_release_by_tag_url(owner, repo, tag) {
+    Ok(url) => url
+    Err(err) => return Err(err)
+  }
+  let mut result : Result[Bool, (Int, String)] = Err(
+    (0, "request was not executed"),
+  )
+  @async.run_async_main(() => {
+    let headers = {
+      "User-Agent": @papion.cli_user_agent(),
+      "Accept": "application/vnd.github+json",
+    }
+    if github_token() is Some(token) {
+      headers["Authorization"] = "Bearer \{token}"
+    }
+    let request : Result[Bool, (Int, String)] = try {
+      let immutable = @async.retry(
+        @async.ExponentialDelay(initial=1000, factor=2.0, maximum=10000),
+        max_retry=3,
+        fatal_error=fn(err) {
+          match err {
+            HttpError((code, _)) =>
+              code == 0 || (code >= 400 && code < 500 && code != 429)
+            _ => false
+          }
+        },
+        () => {
+          let pair = @async.with_timeout(30000, () => @http.get(url, headers~))
+          let (response, body) = pair
+          match response.code {
+            200 =>
+              match
+                extract_release_immutable_field(body.text(), owner, repo, tag) {
+                Ok(immutable) => immutable
+                Err(err) => raise HttpError(err)
+              }
+            404 => false
+            _ =>
+              raise HttpError(
+                (
+                  response.code,
+                  "failed to fetch release metadata for \{owner}/\{repo}@\{tag} (\{response.code} \{response.reason})",
+                ),
+              )
+          }
+        },
+      )
+      Ok(immutable)
+    } catch {
+      HttpError(err) => Err(err)
+      err =>
+        Err(
+          (
+            0,
+            "failed to fetch release metadata for \{owner}/\{repo}@\{tag}: \{err}",
+          ),
+        )
+    }
+    match request {
+      Ok(immutable) => result = Ok(immutable)
+      Err(err) => result = Err(err)
+    }
+  })
+  result
+}
+
+///|
+fn fetch_commit_exists(
+  owner : String,
+  repo : String,
+  sha : String,
+) -> Result[Bool, (Int, String)] {
+  let url = match github_commit_url(owner, repo, sha) {
+    Ok(url) => url
+    Err(err) => return Err(err)
+  }
+  let mut result : Result[Bool, (Int, String)] = Err(
+    (0, "request was not executed"),
+  )
+  @async.run_async_main(() => {
+    let headers = {
+      "User-Agent": @papion.cli_user_agent(),
+      "Accept": "application/vnd.github+json",
+    }
+    if github_token() is Some(token) {
+      headers["Authorization"] = "Bearer \{token}"
+    }
+    let request : Result[Bool, (Int, String)] = try {
+      let exists = @async.retry(
+        @async.ExponentialDelay(initial=1000, factor=2.0, maximum=10000),
+        max_retry=3,
+        fatal_error=fn(err) {
+          match err {
+            HttpError((code, _)) =>
+              code == 0 || (code >= 400 && code < 500 && code != 429)
+            _ => false
+          }
+        },
+        () => {
+          let pair = @async.with_timeout(30000, () => @http.get(url, headers~))
+          let (response, _) = pair
+          match response.code {
+            200 => true
+            404 => false
+            _ =>
+              raise HttpError(
+                (
+                  response.code,
+                  "failed to verify commit SHA for \{owner}/\{repo}@\{sha} (\{response.code} \{response.reason})",
+                ),
+              )
+          }
+        },
+      )
+      Ok(exists)
+    } catch {
+      HttpError(err) => Err(err)
+      err =>
+        Err(
+          (0, "failed to verify commit SHA for \{owner}/\{repo}@\{sha}: \{err}"),
+        )
+    }
+    match request {
+      Ok(exists) => result = Ok(exists)
       Err(err) => result = Err(err)
     }
   })
@@ -581,5 +793,23 @@ pub fn fetch_action_yml(
   match action_yml {
     Ok(action_yml) => Ok((action_yml, resolved_git_ref))
     Err(_) => Err("GitHub action file is not valid UTF-8")
+  }
+}
+
+///|
+pub fn resolve_ref_kind_via_api(
+  owner : String,
+  repo : String,
+  git_ref : String,
+) -> @papion.RefKind {
+  if @rules.classify_ref(git_ref) == Sha {
+    match fetch_commit_exists(owner, repo, git_ref) {
+      Ok(true) => return Sha
+      _ => return Branch
+    }
+  }
+  match fetch_release_by_tag(owner, repo, git_ref) {
+    Ok(true) => ImmutableRelease
+    _ => Branch
   }
 }

--- a/core/native/github.mbt
+++ b/core/native/github.mbt
@@ -796,9 +796,11 @@ pub fn resolve_ref_kind_via_api(
   repo : String,
   git_ref : String,
 ) -> @papion.RefKind {
-  match fetch_commit_exists(owner, repo, git_ref) {
-    Ok(true) => return Sha
-    _ => ()
+  if @rules.classify_ref(git_ref) == Sha {
+    match fetch_commit_exists(owner, repo, git_ref) {
+      Ok(true) => return Sha
+      _ => ()
+    }
   }
   match fetch_release_by_tag(owner, repo, git_ref) {
     Ok(true) => ImmutableRelease

--- a/core/native/github.mbt
+++ b/core/native/github.mbt
@@ -223,13 +223,7 @@ fn github_release_by_tag_url(
     let url = @url.Url::parse("https://api.github.com")
     let enc_owner = @cli.percent_encode_path_component(owner)
     let enc_repo = @cli.percent_encode_path_component(repo)
-    let enc_tag = tag
-      .split("/")
-      .map(fn(segment) {
-        @cli.percent_encode_path_component(segment.to_string())
-      })
-      .to_array()
-      .join("/")
+    let enc_tag = @cli.percent_encode_path_component(tag)
     url.set_pathname("/repos/\{enc_owner}/\{enc_repo}/releases/tags/\{enc_tag}")
     Ok(url.to_string())
   } catch {

--- a/core/native/github.mbt
+++ b/core/native/github.mbt
@@ -791,19 +791,32 @@ pub fn fetch_action_yml(
 }
 
 ///|
+fn resolve_ref_kind_impl(
+  git_ref : String,
+  commit_exists : (String, String, String) -> Result[Bool, (Int, String)],
+  release_immutable : (String, String, String) -> Result[Bool, (Int, String)],
+  owner : String,
+  repo : String,
+) -> @papion.RefKind {
+  if @rules.classify_ref(git_ref) == Sha {
+    match commit_exists(owner, repo, git_ref) {
+      Ok(true) => return Sha
+      _ => ()
+    }
+  }
+  match release_immutable(owner, repo, git_ref) {
+    Ok(true) => ImmutableRelease
+    _ => Branch
+  }
+}
+
+///|
 pub fn resolve_ref_kind_via_api(
   owner : String,
   repo : String,
   git_ref : String,
 ) -> @papion.RefKind {
-  if @rules.classify_ref(git_ref) == Sha {
-    match fetch_commit_exists(owner, repo, git_ref) {
-      Ok(true) => return Sha
-      _ => ()
-    }
-  }
-  match fetch_release_by_tag(owner, repo, git_ref) {
-    Ok(true) => ImmutableRelease
-    _ => Branch
-  }
+  resolve_ref_kind_impl(
+    git_ref, fetch_commit_exists, fetch_release_by_tag, owner, repo,
+  )
 }

--- a/core/native/main.mbt
+++ b/core/native/main.mbt
@@ -29,5 +29,10 @@ fn main {
 
 ///|
 fn run(args : Array[String]) -> Result[@cli.RunOutcome, @cli.CliError] {
-  @cli.run_with_host(args, load_config, fetch_action_yml)
+  @cli.run_with_host(
+    args,
+    load_config,
+    fetch_action_yml,
+    resolve_ref_kind=resolve_ref_kind_via_api,
+  )
 }

--- a/core/native/moon.pkg
+++ b/core/native/moon.pkg
@@ -1,7 +1,6 @@
 import {
   "maruloop/papion/cli",
   "maruloop/papion",
-  "maruloop/papion/rules",
   "moonbitlang/async",
   "moonbitlang/async/http",
   "moonbitlang/core/buffer",

--- a/core/native/moon.pkg
+++ b/core/native/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "maruloop/papion/cli",
   "maruloop/papion",
+  "maruloop/papion/rules",
   "moonbitlang/async",
   "moonbitlang/async/http",
   "moonbitlang/core/buffer",

--- a/core/native/native_wbtest.mbt
+++ b/core/native/native_wbtest.mbt
@@ -123,6 +123,29 @@ test "github_repo_url encodes owner and repo path segments" {
 }
 
 ///|
+test "github_release_by_tag_url encodes owner repo and tag path segments" {
+  let url = match
+    github_release_by_tag_url("maru/loop", "pa pion", "v1.0.0/rc 1") {
+    Ok(url) => url
+    Err(err) => fail(err.1)
+  }
+  assert_eq(
+    url, "https://api.github.com/repos/maru%2Floop/pa%20pion/releases/tags/v1.0.0/rc%201",
+  )
+}
+
+///|
+test "github_commit_url encodes owner repo and sha path segments" {
+  let url = match github_commit_url("maru/loop", "pa pion", "abc/123") {
+    Ok(url) => url
+    Err(err) => fail(err.1)
+  }
+  assert_eq(
+    url, "https://api.github.com/repos/maru%2Floop/pa%20pion/git/commits/abc%2F123",
+  )
+}
+
+///|
 test "extract_matching_refs_field returns stripped refs" {
   assert_eq(
     extract_matching_refs_field(
@@ -209,6 +232,62 @@ test "extract_default_branch_field errors when default_branch is not string" {
     Err(
       (
         0, "GitHub repository response for octocat/hello-world did not contain a string default_branch field",
+      ),
+    ),
+  )
+}
+
+///|
+test "extract_release_immutable_field returns true when immutable is true" {
+  assert_eq(
+    extract_release_immutable_field(
+      "{\"immutable\":true}", "octocat", "hello-world", "v1",
+    ),
+    Ok(true),
+  )
+}
+
+///|
+test "extract_release_immutable_field returns false when immutable is false" {
+  assert_eq(
+    extract_release_immutable_field(
+      "{\"immutable\":false}", "octocat", "hello-world", "v1",
+    ),
+    Ok(false),
+  )
+}
+
+///|
+test "extract_release_immutable_field returns false when immutable missing" {
+  assert_eq(
+    extract_release_immutable_field(
+      "{\"tag_name\":\"v1\"}", "octocat", "hello-world", "v1",
+    ),
+    Ok(false),
+  )
+}
+
+///|
+test "extract_release_immutable_field errors when immutable is not bool" {
+  assert_eq(
+    extract_release_immutable_field(
+      "{\"immutable\":123}", "octocat", "hello-world", "v1",
+    ),
+    Err(
+      (
+        0, "GitHub release response for octocat/hello-world@v1 did not contain a boolean immutable field",
+      ),
+    ),
+  )
+}
+
+///|
+test "extract_release_immutable_field errors on parse failure" {
+  assert_eq(
+    extract_release_immutable_field("{", "octocat", "hello-world", "v1"),
+    Err(
+      (
+        0, "failed to parse GitHub release response for octocat/hello-world@v1: Unexpected end of file",
       ),
     ),
   )

--- a/core/native/native_wbtest.mbt
+++ b/core/native/native_wbtest.mbt
@@ -130,7 +130,7 @@ test "github_release_by_tag_url encodes owner repo and tag path segments" {
     Err(err) => fail(err.1)
   }
   assert_eq(
-    url, "https://api.github.com/repos/maru%2Floop/pa%20pion/releases/tags/v1.0.0/rc%201",
+    url, "https://api.github.com/repos/maru%2Floop/pa%20pion/releases/tags/v1.0.0%2Frc%201",
   )
 }
 

--- a/core/native/native_wbtest.mbt
+++ b/core/native/native_wbtest.mbt
@@ -385,3 +385,115 @@ test "run parse_args error on --config propagates before fetch" {
   assert_eq(load_config_called, false)
   assert_eq(fetch_called, false)
 }
+
+// Helpers for resolve_ref_kind_impl tests
+
+///|
+fn commit_ok(
+  exists : Bool,
+) -> (String, String, String) -> Result[Bool, (Int, String)] {
+  fn(_owner, _repo, _ref) { Ok(exists) }
+}
+
+///|
+fn commit_err() -> (String, String, String) -> Result[Bool, (Int, String)] {
+  fn(_owner, _repo, _ref) { Err((500, "api error")) }
+}
+
+///|
+fn release_ok(
+  immutable : Bool,
+) -> (String, String, String) -> Result[Bool, (Int, String)] {
+  fn(_owner, _repo, _ref) { Ok(immutable) }
+}
+
+///|
+fn release_err() -> (String, String, String) -> Result[Bool, (Int, String)] {
+  fn(_owner, _repo, _ref) { Err((500, "api error")) }
+}
+
+///|
+fn must_not_call() -> (String, String, String) -> Result[Bool, (Int, String)] {
+  fn(_owner, _repo, _ref) { panic() }
+}
+
+// SHA-shaped ref (40 hex chars)
+
+///|
+let sha_ref : String = "a" + String::make(39, 'b')
+
+///|
+test "resolve_ref_kind_impl: sha-shaped + commit exists => Sha" {
+  assert_eq(
+    resolve_ref_kind_impl(sha_ref, commit_ok(true), must_not_call(), "o", "r"),
+    Sha,
+  )
+}
+
+///|
+test "resolve_ref_kind_impl: sha-shaped + commit missing + immutable release => ImmutableRelease" {
+  assert_eq(
+    resolve_ref_kind_impl(sha_ref, commit_ok(false), release_ok(true), "o", "r"),
+    ImmutableRelease,
+  )
+}
+
+///|
+test "resolve_ref_kind_impl: sha-shaped + commit missing + mutable release => Branch" {
+  assert_eq(
+    resolve_ref_kind_impl(
+      sha_ref,
+      commit_ok(false),
+      release_ok(false),
+      "o",
+      "r",
+    ),
+    Branch,
+  )
+}
+
+///|
+test "resolve_ref_kind_impl: sha-shaped + commit error + immutable release => ImmutableRelease" {
+  assert_eq(
+    resolve_ref_kind_impl(sha_ref, commit_err(), release_ok(true), "o", "r"),
+    ImmutableRelease,
+  )
+}
+
+///|
+test "resolve_ref_kind_impl: sha-shaped + commit error + release error => Branch" {
+  assert_eq(
+    resolve_ref_kind_impl(sha_ref, commit_err(), release_err(), "o", "r"),
+    Branch,
+  )
+}
+
+///|
+test "resolve_ref_kind_impl: non-sha ref + immutable release => ImmutableRelease" {
+  assert_eq(
+    resolve_ref_kind_impl("v1.5.0", must_not_call(), release_ok(true), "o", "r"),
+    ImmutableRelease,
+  )
+}
+
+///|
+test "resolve_ref_kind_impl: non-sha ref + mutable release => Branch" {
+  assert_eq(
+    resolve_ref_kind_impl(
+      "v1.5.0",
+      must_not_call(),
+      release_ok(false),
+      "o",
+      "r",
+    ),
+    Branch,
+  )
+}
+
+///|
+test "resolve_ref_kind_impl: non-sha ref + release error => Branch" {
+  assert_eq(
+    resolve_ref_kind_impl("main", must_not_call(), release_err(), "o", "r"),
+    Branch,
+  )
+}

--- a/core/native/pkg.generated.mbti
+++ b/core/native/pkg.generated.mbti
@@ -10,6 +10,8 @@ pub fn fetch_action_yml(String, String, String?, String?, Bool) -> Result[(Strin
 
 pub fn load_config(String?) -> Result[@papion.Policy, String]
 
+pub fn resolve_ref_kind_via_api(String, String, String) -> @papion.RefKind
+
 // Errors
 
 // Types and methods

--- a/core/papion.mbt
+++ b/core/papion.mbt
@@ -44,6 +44,7 @@ pub(all) enum RefKind {
   Sha
   Tag
   Branch
+  ImmutableRelease
 } derive(Debug, Eq, ToJson, FromJson)
 
 ///|

--- a/core/papion_test.mbt
+++ b/core/papion_test.mbt
@@ -29,15 +29,19 @@ test "RefKind json roundtrip" {
   let sha : @papion.RefKind = Sha
   let tag : @papion.RefKind = Tag
   let branch : @papion.RefKind = Branch
+  let immutable_release : @papion.RefKind = ImmutableRelease
   let s_json = @json.parse(sha.to_json().stringify())
   let t_json = @json.parse(tag.to_json().stringify())
   let b_json = @json.parse(branch.to_json().stringify())
+  let i_json = @json.parse(immutable_release.to_json().stringify())
   let s_back : @papion.RefKind = @json.from_json(s_json)
   let t_back : @papion.RefKind = @json.from_json(t_json)
   let b_back : @papion.RefKind = @json.from_json(b_json)
+  let i_back : @papion.RefKind = @json.from_json(i_json)
   assert_eq(sha, s_back)
   assert_eq(tag, t_back)
   assert_eq(branch, b_back)
+  assert_eq(immutable_release, i_back)
 }
 
 ///|

--- a/core/pkg.generated.mbti
+++ b/core/pkg.generated.mbti
@@ -67,6 +67,7 @@ pub(all) enum RefKind {
   Sha
   Tag
   Branch
+  ImmutableRelease
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub impl Show for RefKind
 

--- a/core/rules/pkg.generated.mbti
+++ b/core/rules/pkg.generated.mbti
@@ -10,11 +10,11 @@ pub fn check_allowed(@papion.ActionRef, @papion.Policy) -> Array[@papion.Finding
 
 pub fn check_disallowed(@papion.ActionRef, @papion.Policy) -> Array[@papion.Finding]
 
-pub fn check_sha_pinning(@papion.ActionRef, @papion.Policy) -> Array[@papion.Finding]
+pub fn check_sha_pinning(@papion.ActionRef, @papion.RefKind, @papion.Policy) -> Array[@papion.Finding]
 
 pub fn classify_ref(String) -> @papion.RefKind
 
-pub fn evaluate(@papion.ActionRef, @papion.Policy) -> Array[@papion.Finding]
+pub fn evaluate(@papion.ActionRef, @papion.RefKind, @papion.Policy) -> Array[@papion.Finding]
 
 // Errors
 

--- a/core/rules/rules.mbt
+++ b/core/rules/rules.mbt
@@ -30,9 +30,9 @@ pub fn classify_ref(git_ref : String) -> @papion.RefKind {
 ///|
 /// Check the SHA-pinning rule against an action reference.
 ///
-/// Produces a Fail finding when sha_pinning is enabled and the ref is not a
-/// 40-character hex SHA (case-insensitive). Returns an empty array when the
-/// rule is disabled or the ref is already pinned.
+/// Produces a Fail finding when sha_pinning is enabled and the ref is neither
+/// a verified commit SHA nor an immutable release. Returns an empty array when
+/// the rule is disabled or the ref is already pinned.
 pub fn check_sha_pinning(
   action_ref : @papion.ActionRef,
   ref_kind : @papion.RefKind,

--- a/core/rules/rules.mbt
+++ b/core/rules/rules.mbt
@@ -35,13 +35,15 @@ pub fn classify_ref(git_ref : String) -> @papion.RefKind {
 /// rule is disabled or the ref is already pinned.
 pub fn check_sha_pinning(
   action_ref : @papion.ActionRef,
+  ref_kind : @papion.RefKind,
   policy : @papion.Policy,
 ) -> Array[@papion.Finding] {
   if !policy.sha_pinning {
     return []
   }
-  if classify_ref(action_ref.git_ref) == Sha {
-    return []
+  match ref_kind {
+    Sha | ImmutableRelease => return []
+    _ => ()
   }
   [
     {
@@ -49,7 +51,7 @@ pub fn check_sha_pinning(
       rule: "sha-pinning",
       target: format_target(action_ref),
       context: None,
-      message: "action ref is not pinned to a SHA — use a 40-character hex commit SHA instead of a tag or branch name",
+      message: "action ref is not pinned to a SHA or immutable release",
       suggestion: None,
     },
   ]
@@ -111,10 +113,11 @@ pub fn check_disallowed(
 /// All findings are collected — rules are independent.
 pub fn evaluate(
   action_ref : @papion.ActionRef,
+  ref_kind : @papion.RefKind,
   policy : @papion.Policy,
 ) -> Array[@papion.Finding] {
   let findings : Array[@papion.Finding] = []
-  findings.append(check_sha_pinning(action_ref, policy))
+  findings.append(check_sha_pinning(action_ref, ref_kind, policy))
   findings.append(check_allowed(action_ref, policy))
   findings.append(check_disallowed(action_ref, policy))
   findings

--- a/core/rules/rules.mbt
+++ b/core/rules/rules.mbt
@@ -52,7 +52,9 @@ pub fn check_sha_pinning(
       target: format_target(action_ref),
       context: None,
       message: "action ref is not pinned to a SHA or immutable release",
-      suggestion: None,
+      suggestion: Some(
+        "pin to a full commit SHA (e.g. @abc123...) or an immutable release tag",
+      ),
     },
   ]
 }

--- a/core/rules/rules_test.mbt
+++ b/core/rules/rules_test.mbt
@@ -52,7 +52,7 @@ test "check_sha_pinning SHA ref passes" {
     path: None,
   }
   let policy = @papion.Policy::default()
-  assert_eq(check_sha_pinning(action_ref, policy), [])
+  assert_eq(check_sha_pinning(action_ref, Sha, policy), [])
 }
 
 ///|
@@ -64,11 +64,45 @@ test "check_sha_pinning non-SHA ref fails" {
     path: None,
   }
   let policy = @papion.Policy::default()
-  let findings = check_sha_pinning(action_ref, policy)
+  let findings = check_sha_pinning(action_ref, Branch, policy)
   assert_eq(findings.length(), 1)
   assert_eq(findings[0].level, @papion.FindingLevel::Fail)
   assert_eq(findings[0].rule, "sha-pinning")
   assert_eq(findings[0].target, "actions/checkout@v4")
+  assert_eq(
+    findings[0].message,
+    "action ref is not pinned to a SHA or immutable release",
+  )
+}
+
+///|
+test "check_sha_pinning immutable release passes" {
+  let action_ref : @papion.ActionRef = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "v4",
+    path: None,
+  }
+  let policy = @papion.Policy::default()
+  assert_eq(check_sha_pinning(action_ref, ImmutableRelease, policy), [])
+}
+
+///|
+test "check_sha_pinning tag ref fails" {
+  let action_ref : @papion.ActionRef = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "v4",
+    path: None,
+  }
+  let policy = @papion.Policy::default()
+  let findings = check_sha_pinning(action_ref, Tag, policy)
+  assert_eq(findings.length(), 1)
+  assert_eq(findings[0].rule, "sha-pinning")
+  assert_eq(
+    findings[0].message,
+    "action ref is not pinned to a SHA or immutable release",
+  )
 }
 
 ///|
@@ -84,7 +118,7 @@ test "check_sha_pinning disabled skips" {
     allowed: [],
     disallowed: [],
   }
-  assert_eq(check_sha_pinning(action_ref, policy), [])
+  assert_eq(check_sha_pinning(action_ref, Branch, policy), [])
 }
 
 ///|
@@ -184,7 +218,7 @@ test "evaluate SHA ref empty policy produces no findings" {
     path: None,
   }
   let policy = @papion.Policy::default()
-  assert_eq(evaluate(action_ref, policy), [])
+  assert_eq(evaluate(action_ref, Sha, policy), [])
 }
 
 ///|
@@ -196,9 +230,25 @@ test "evaluate non-SHA ref default policy produces sha-pinning finding" {
     path: None,
   }
   let policy = @papion.Policy::default()
-  let findings = evaluate(action_ref, policy)
+  let findings = evaluate(action_ref, Branch, policy)
   assert_eq(findings.length(), 1)
   assert_eq(findings[0].rule, "sha-pinning")
+  assert_eq(
+    findings[0].message,
+    "action ref is not pinned to a SHA or immutable release",
+  )
+}
+
+///|
+test "evaluate immutable release produces no sha-pinning finding" {
+  let action_ref : @papion.ActionRef = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "v4",
+    path: None,
+  }
+  let policy = @papion.Policy::default()
+  assert_eq(evaluate(action_ref, ImmutableRelease, policy), [])
 }
 
 ///|
@@ -214,7 +264,7 @@ test "evaluate non-SHA ref not in allowed list produces two findings" {
     allowed: ["github/*"],
     disallowed: [],
   }
-  let findings = evaluate(action_ref, policy)
+  let findings = evaluate(action_ref, Branch, policy)
   assert_eq(findings.length(), 2)
   assert_eq(findings[0].rule, "sha-pinning")
   assert_eq(findings[1].rule, "allowed-list")
@@ -233,7 +283,7 @@ test "evaluate action in both allowed and disallowed produces disallowed finding
     allowed: ["actions/*"],
     disallowed: ["actions/*"],
   }
-  let findings = evaluate(action_ref, policy)
+  let findings = evaluate(action_ref, Sha, policy)
   assert_eq(findings.length(), 1)
   assert_eq(findings[0].rule, "disallowed-list")
 }
@@ -247,7 +297,7 @@ test "check_sha_pinning with path includes path in target" {
     path: Some("deploy"),
   }
   let policy = @papion.Policy::default()
-  let findings = check_sha_pinning(action_ref, policy)
+  let findings = check_sha_pinning(action_ref, Branch, policy)
   assert_eq(findings.length(), 1)
   assert_eq(findings[0].target, "myorg/actions/deploy@v2")
 }
@@ -265,7 +315,7 @@ test "evaluate with path includes path in finding target" {
     allowed: ["github/*"],
     disallowed: [],
   }
-  let findings = evaluate(action_ref, policy)
+  let findings = evaluate(action_ref, Sha, policy)
   assert_eq(findings.length(), 1)
   assert_eq(findings[0].rule, "allowed-list")
   assert_eq(
@@ -287,5 +337,5 @@ test "evaluate all passing produces no findings" {
     allowed: ["actions/*"],
     disallowed: ["bad-org/*"],
   }
-  assert_eq(evaluate(action_ref, policy), [])
+  assert_eq(evaluate(action_ref, Sha, policy), [])
 }

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -532,6 +532,36 @@ Adopt the fourth option — fetch only the single file via the GitHub Contents A
 * Very deep slash-containing refs in pasted GitHub tree URLs may still fail native fallback resolution today; widening the cap remains an explicit future adjustment if real usage justifies the extra requests
 * The CLI host layer is split into target-aware packages so target-specific dependencies are represented structurally instead of through keepalive references.
 
+### Ref-kind resolution boundary
+
+Papion now treats ref-kind resolution as a host responsibility rather than a pure rules concern.
+
+The decision is:
+
+* `core/rules` receives `RefKind` as input data and stays pure
+* `core/engine.scan` accepts an injected `resolve_ref_kind` callback with a pure `classify_ref` fallback
+* native hosts may use GitHub API calls to refine that classification before evaluation
+
+This keeps the core contract honest:
+
+* pure and WASM environments can still classify refs structurally with no I/O
+* native hosts can verify whether a 40-character hex string actually exists as a commit SHA
+* native hosts can treat immutable GitHub releases as equivalent to SHA pins for policy evaluation
+
+### Immutable releases as SHA-equivalent pins
+
+Papion's `sha-pinning` rule now accepts either:
+
+* a verified commit SHA
+* an immutable GitHub release tag
+
+On native targets, the host checks:
+
+* `git/commits/{sha}` to verify that SHA-like refs really exist
+* `releases/tags/{tag}` and its `immutable` field to recognize immutable releases
+
+If either API check fails, the host fails closed and reports the ref to the pure rules layer as `Branch`, so Papion never grants a pass based on an unverifiable ref.
+
 ### CLI package boundaries
 
 The CLI is packaged as:

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -560,7 +560,7 @@ On native targets, the host checks:
 * `git/commits/{sha}` to verify that SHA-like refs really exist
 * `releases/tags/{tag}` and its `immutable` field to recognize immutable releases
 
-If either API check fails, the host fails closed and reports the ref to the pure rules layer as `Branch`, so Papion never grants a pass based on an unverifiable ref.
+The host checks in sequence: if the SHA lookup succeeds the ref is confirmed as `Sha`; if the release lookup succeeds it is confirmed as `ImmutableRelease`. Only if neither check confirms the ref does the host fall back to `Branch`, so Papion never grants a pass based on an unverifiable ref.
 
 ### CLI package boundaries
 


### PR DESCRIPTION
Closes #20.

## Summary

- Inject a host-provided `resolve_ref_kind` callback into `engine.scan` so rules consume `RefKind` as pure data
- Treat immutable GitHub releases as equivalent to SHA pins
- Verify SHA-like refs via the GitHub commits API on native targets
- Add `RefKind.ImmutableRelease` variant

## Changes

- `core/papion.mbt` — `RefKind.ImmutableRelease` variant
- `core/rules/rules.mbt` — `check_sha_pinning` accepts `RefKind`, adds actionable suggestion
- `core/engine/engine.mbt` — `resolve_ref_kind?` callback parameter
- `core/native/github.mbt` — `resolve_ref_kind_via_api`, `fetch_release_by_tag`, `fetch_commit_exists`, tag URL encoding
- `core/cli/run.mbt` — passes `resolve_ref_kind` to engine
- `core/README.mbt.md` — updated package table and build targets
- `docs/adr.md` — Decision 19 ref-kind boundary section

## Test plan

- [x] `moon fmt --check` passes
- [x] `moon test --deny-warn` — 159 tests pass
- [x] `moon test --target native --deny-warn` — 195 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)