### PR TITLE
feat(engine): recursive transitive scanning via BFS

### DIFF
--- a/core/README.mbt.md
+++ b/core/README.mbt.md
@@ -1,17 +1,20 @@
 # Papion Core
 
-Pure MoonBit engine for scanning GitHub Actions. No I/O, no host imports — all data exchange happens via JSON strings at the WASM boundary.
+Pure MoonBit engine for scanning GitHub Actions. Core logic is portable and environment-agnostic. Host-specific I/O (GitHub API, file system) is injected via callbacks.
 
 ## Packages
 
 | Package | Purpose |
 |---------|---------|
 | `papion` (root) | Core data types shared by all packages |
-| `papion/parser` | Parse action.yml JSON into core types |
+| `papion/parser` | Parse action.yml YAML into core types |
 | `papion/config` | Parse policy configuration JSON, glob matching for allowed/disallowed lists |
-| `papion/rules` | Evaluate policy rules against action references (**this PR**) |
-| `papion/format` | Format scan results as human-readable or JSON output (planned: WS7) |
-| `papion/engine` | Orchestrate a full scan (WASM entry point) (planned: WS5) |
+| `papion/rules` | Evaluate policy rules against action references |
+| `papion/format` | Format scan results as human-readable or JSON output |
+| `papion/engine` | Orchestrate a full scan |
+| `papion/cli` | Target-agnostic argument parsing, orchestration, formatting selection |
+| `papion/native` | Native CLI executable, GitHub API integration, file I/O |
+| `papion/wasm` | WASM/browser-facing stubs and host bindings |
 
 ## Data Model
 
@@ -33,7 +36,7 @@ ActionRef {
 Classifies the type of ref.
 
 ```
-RefKind = Sha | Tag | Branch
+RefKind = Sha | Tag | Branch | ImmutableRelease
 ```
 
 ### ActionYml
@@ -140,6 +143,6 @@ Summary {
 ## Build Targets
 
 ```sh
-moon build --target wasm-gc    # WASM for Go CLI
-moon build --target js         # JS for browser / Cloudflare
+moon build --target native   # Native CLI binary
+moon build --target js       # JS for browser / Cloudflare
 ```

--- a/core/README.mbt.md
+++ b/core/README.mbt.md
@@ -144,5 +144,6 @@ Summary {
 
 ```sh
 moon build --target native   # Native CLI binary
-moon build --target js       # JS for browser / Cloudflare
+moon build --target js       # JS for browser / Cloudflare Workers
+moon build --target wasm-gc  # WASM (GC) for browser embedding
 ```

--- a/core/cli/cli_test.mbt
+++ b/core/cli/cli_test.mbt
@@ -441,6 +441,49 @@ test "run_with_host passes allow_ref_fallback for github tree urls" {
 }
 
 ///|
+test "run_with_host passes custom ref kind resolver into engine" {
+  let mut resolver_called = false
+  let mut resolved_owner = ""
+  let mut resolved_repo = ""
+  let mut resolved_git_ref = ""
+  let result = run_with_host(
+    ["run", "actions/checkout@v4", "--format", "json"],
+    fn(_config_path) { Ok(@papion.Policy::default()) },
+    fn(_owner, _repo, _git_ref, _path, _allow_ref_fallback) {
+      Ok(
+        (
+          (
+            #|name: Composite
+            #|runs:
+            #|  using: composite
+            #|  steps:
+            #|    - uses: actions/checkout@v4
+          ),
+          "v4",
+        ),
+      )
+    },
+    resolve_ref_kind=fn(owner, repo, git_ref) {
+      resolver_called = true
+      resolved_owner = owner
+      resolved_repo = repo
+      resolved_git_ref = git_ref
+      @papion.RefKind::ImmutableRelease
+    },
+  )
+  match result {
+    Ok(outcome) => {
+      assert_eq(resolver_called, true)
+      assert_eq(resolved_owner, "actions")
+      assert_eq(resolved_repo, "checkout")
+      assert_eq(resolved_git_ref, "v4")
+      assert_true(outcome.output.contains("\"findings\":[]"))
+    }
+    Err(err) => fail(err.to_string())
+  }
+}
+
+///|
 test "exit_code_for fail_on fail clean" {
   assert_eq(exit_code_for({ failures: 0, warnings: 0 }, Fail), 0)
 }

--- a/core/cli/moon.pkg
+++ b/core/cli/moon.pkg
@@ -2,6 +2,7 @@ import {
   "maruloop/papion/engine",
   "maruloop/papion/format",
   "maruloop/papion",
+  "maruloop/papion/rules",
   "moonbitlang/core/buffer",
   "moonbitlang/core/encoding/utf8",
 }

--- a/core/cli/pkg.generated.mbti
+++ b/core/cli/pkg.generated.mbti
@@ -15,7 +15,7 @@ pub fn percent_decode_url_path_segment(String) -> Result[String, String]
 
 pub fn percent_encode_path_component(String) -> String
 
-pub fn run_with_host(Array[String], (String?) -> Result[@papion.Policy, String], (String, String, String?, String?, Bool) -> Result[(String, String), String]) -> Result[RunOutcome, CliError]
+pub fn run_with_host(Array[String], (String?) -> Result[@papion.Policy, String], (String, String, String?, String?, Bool) -> Result[(String, String), String], resolve_ref_kind? : (String, String, String) -> @papion.RefKind) -> Result[RunOutcome, CliError]
 
 // Errors
 

--- a/core/cli/run.mbt
+++ b/core/cli/run.mbt
@@ -57,12 +57,22 @@ pub fn run_with_host(
     Ok(result) => result
     Err(err) => return Err(RuntimeError(err))
   }
+  let engine_fetch : ((String, String, String, String?) -> Result[
+    String,
+    String,
+  ])? = Some(fn(owner, repo, git_ref, path) {
+    match fetch_action_yml(owner, repo, Some(git_ref), path, false) {
+      Ok((yaml, _)) => Ok(yaml)
+      Err(err) => Err(err)
+    }
+  })
   let result = match
     @engine.scan(
       { owner: options.owner, repo: options.repo, git_ref: resolved_git_ref },
       action_yml,
       policy,
       resolve_ref_kind~,
+      fetch_action_yml=engine_fetch,
     ) {
     Ok(result) => result
     Err(err) => return Err(RuntimeError(err))

--- a/core/cli/run.mbt
+++ b/core/cli/run.mbt
@@ -30,6 +30,13 @@ pub fn run_with_host(
     (String, String),
     String,
   ],
+  resolve_ref_kind? : (String, String, String) -> @papion.RefKind = fn(
+    _owner,
+    _repo,
+    git_ref,
+  ) {
+    @rules.classify_ref(git_ref)
+  },
 ) -> Result[RunOutcome, CliError] {
   let options = match parse_args(args) {
     Ok(options) => options
@@ -55,6 +62,7 @@ pub fn run_with_host(
       { owner: options.owner, repo: options.repo, git_ref: resolved_git_ref },
       action_yml,
       policy,
+      resolve_ref_kind~,
     ) {
     Ok(result) => result
     Err(err) => return Err(RuntimeError(err))

--- a/core/engine/README.mbt.md
+++ b/core/engine/README.mbt.md
@@ -1,6 +1,6 @@
 # core/engine
 
-Scan orchestrator. Wires parser, config, and rules into a single entry point.
+Scan orchestrator. Wires parser, config, and rules into a single entry point. Supports optional BFS traversal of transitive composite-action dependencies.
 
 ## API
 
@@ -9,14 +9,18 @@ pub fn scan(
   target : @papion.ScanTarget,
   action_yml_yaml : String,
   policy : @papion.Policy,
+  resolve_ref_kind~ : (String, String, String) -> @papion.RefKind = ...,
+  fetch_action_yml~ : ((String, String, String, String?) -> Result[String, String])? = None,
 ) -> Result[@papion.ScanResult, String]
 ```
 
 - `target` — the action being scanned (`owner`, `repo`, `git_ref`)
 - `action_yml_yaml` — raw YAML content of `action.yml`
 - `policy` — papion policy; `scan` normalizes `allowed`/`disallowed` to lowercase and rejects patterns longer than 256 characters before evaluation
+- `resolve_ref_kind~` — optional callback to classify a git ref as `Sha`, `Tag`, `Branch`, or `ImmutableRelease`; defaults to `@rules.classify_ref`
+- `fetch_action_yml~` — optional callback `(owner, repo, git_ref, path?) -> Result[String, String]`; when provided, enables recursive BFS traversal of transitive dependencies
 
-Returns `Ok(ScanResult)` with findings and summary, or `Err(message)` if the YAML is unparseable.
+Returns `Ok(ScanResult)` with findings and summary, or `Err(message)` if the root YAML is unparseable.
 
 ## Behaviour
 
@@ -26,6 +30,8 @@ Before rule evaluation, `scan` normalizes and validates the policy so both CLI c
 - every allowed/disallowed pattern must be at most 256 characters
 - invalid policies fail fast with `Err(...)` rather than silently producing mismatched findings
 
+**Non-recursive mode** (default, `fetch_action_yml~` = `None`):
+
 1. Parse `action_yml_yaml` with `@parser.parse_action_yml`
 2. Normalize and validate `policy`
 3. Extract action refs from composite steps with `@parser.extract_refs`
@@ -33,10 +39,26 @@ Before rule evaluation, `scan` normalizes and validates the policy so both CLI c
 5. Count failures and warnings for the summary
 6. Return `ScanResult { target, findings, summary }`
 
-Non-composite actions (e.g. `using: node20`) produce zero findings from ref extraction but still apply rules to zero refs, so the result is always a valid `ScanResult`.
+**Recursive mode** (`fetch_action_yml~` = `Some(fetch)`):
+
+The engine performs a BFS traversal starting from the root action. For each action in the queue:
+
+1. Parse the YAML; if the root fails, return `Err`; if a transitive node fails, skip it.
+2. Extract and evaluate all refs (same as non-recursive).
+3. For each ref not yet visited, fetch its `action.yml` via the callback and enqueue it.
+4. Traversal is bounded by `max_scan_depth = 10` and `max_scan_nodes = 100` (defined in `core/papion.mbt`).
+5. The visited set is keyed by `owner/repo[/path]@ref` to detect cycles.
+
+**Dependency chain context**: transitive findings include a `context` field showing the full path from the root, e.g. `"org/action-b@v1 > org/action-c@v1"`. Root findings have `context = None`.
+
+Non-composite actions (e.g. `using: node20`) produce zero findings from ref extraction but still result in a valid `ScanResult`.
 
 ## Error handling
 
-- Invalid YAML → `Err("...")`
+- Invalid root YAML → `Err("...")`
 - Empty action_yml_yaml → `Err("empty YAML document")`
 - Invalid policy invariant (for example overlong pattern) → `Err("...")`
+- Transitive fetch error → node silently skipped
+- Transitive parse error → node silently skipped
+- Cycle → visited set prevents re-enqueue; terminates
+- Depth/node limit exceeded → no new children enqueued; already-queued nodes drain normally

--- a/core/engine/engine.mbt
+++ b/core/engine/engine.mbt
@@ -22,6 +22,9 @@ fn action_ref_key(ref_ : @papion.ActionRef) -> String {
 /// re-fetching cycles. Traversal is bounded by `max_scan_depth` and
 /// `max_scan_nodes`. Fetch errors and unparseable transitive YAMLs are silently
 /// skipped; only root parse failures propagate as `Err`.
+///
+/// `resolve_ref_kind` is only called when `policy.sha_pinning` is true,
+/// avoiding unnecessary I/O (e.g. GitHub API calls) when SHA pinning is disabled.
 pub fn scan(
   target : @papion.ScanTarget,
   action_yml_yaml : String,
@@ -60,7 +63,11 @@ pub fn scan(
     }
     let refs = @parser.extract_refs(yml)
     for ref_ in refs {
-      let ref_kind = resolve_ref_kind(ref_.owner, ref_.repo, ref_.git_ref)
+      let ref_kind = if policy.sha_pinning {
+        resolve_ref_kind(ref_.owner, ref_.repo, ref_.git_ref)
+      } else {
+        Branch
+      }
       let findings = @rules.evaluate(ref_, ref_kind, policy)
       let context = if chain.is_empty() {
         None

--- a/core/engine/engine.mbt
+++ b/core/engine/engine.mbt
@@ -1,4 +1,13 @@
 ///|
+fn action_ref_key(ref_ : @papion.ActionRef) -> String {
+  let path_part = match ref_.path {
+    None => ""
+    Some(p) => "/\{p}"
+  }
+  "\{ref_.owner}/\{ref_.repo}\{path_part}@\{ref_.git_ref}"
+}
+
+///|
 /// Scan an action against a policy.
 ///
 /// Parses action_yml_yaml (raw YAML), extracts all action refs from composite
@@ -6,6 +15,13 @@
 /// ScanResult with aggregated findings and summary counts.
 /// The policy is normalized and validated before evaluation so callers may
 /// pass either `parse_policy` output or a programmatically constructed Policy.
+///
+/// When `fetch_action_yml` is provided, the engine performs a BFS traversal of
+/// transitive dependencies. Each fetched action.yml is parsed and its refs are
+/// evaluated. The visited set (keyed by `owner/repo[/path]@ref`) prevents
+/// re-fetching cycles. Traversal is bounded by `max_scan_depth` and
+/// `max_scan_nodes`. Fetch errors and unparseable transitive YAMLs are silently
+/// skipped; only root parse failures propagate as `Err`.
 pub fn scan(
   target : @papion.ScanTarget,
   action_yml_yaml : String,
@@ -17,22 +33,66 @@ pub fn scan(
   ) {
     @rules.classify_ref(git_ref)
   },
+  fetch_action_yml? : ((String, String, String, String?) -> Result[
+    String,
+    String,
+  ])? = None,
 ) -> Result[@papion.ScanResult, String] {
   let policy = match policy.normalized() {
     Ok(policy) => policy
     Err(err) => return Err(err)
   }
-  let yml = match @parser.parse_action_yml(action_yml_yaml) {
-    Ok(y) => y
-    Err(e) => return Err(e)
+  let queue : Array[(String, Int, Array[String])] = []
+  let visited : Map[String, Bool] = {}
+  visited["\{target.owner}/\{target.repo}@\{target.git_ref}"] = true
+  queue.push((action_yml_yaml, 0, []))
+  let all_findings : Array[@papion.Finding] = []
+  let mut node_count = 0
+  let mut i = 0
+  while i < queue.length() {
+    let (yaml_str, depth, chain) = queue[i]
+    i += 1
+    node_count += 1
+    let is_root = node_count == 1
+    let yml = match @parser.parse_action_yml(yaml_str) {
+      Err(e) => if is_root { return Err(e) } else { continue }
+      Ok(y) => y
+    }
+    let refs = @parser.extract_refs(yml)
+    for ref_ in refs {
+      let ref_kind = resolve_ref_kind(ref_.owner, ref_.repo, ref_.git_ref)
+      let findings = @rules.evaluate(ref_, ref_kind, policy)
+      let context = if chain.is_empty() {
+        None
+      } else {
+        Some(chain.join(" > "))
+      }
+      for f in findings {
+        all_findings.push({ ..f, context, })
+      }
+      match fetch_action_yml {
+        None => ()
+        Some(fetch) => {
+          let ref_key = action_ref_key(ref_)
+          if visited.get(ref_key) is None {
+            visited[ref_key] = true
+            if depth < @papion.max_scan_depth &&
+              node_count < @papion.max_scan_nodes {
+              match fetch(ref_.owner, ref_.repo, ref_.git_ref, ref_.path) {
+                Ok(yaml) => {
+                  let child_chain = chain.copy()
+                  child_chain.push(action_ref_key(ref_))
+                  queue.push((yaml, depth + 1, child_chain))
+                }
+                Err(_) => ()
+              }
+            }
+          }
+        }
+      }
+    }
   }
-  let refs = @parser.extract_refs(yml)
-  let findings : Array[@papion.Finding] = []
-  for ref_ in refs {
-    let ref_kind = resolve_ref_kind(ref_.owner, ref_.repo, ref_.git_ref)
-    findings.append(@rules.evaluate(ref_, ref_kind, policy))
-  }
-  let failures = findings.iter().filter(fn(f) { f.level == Fail }).count()
-  let warnings = findings.iter().filter(fn(f) { f.level == Warn }).count()
-  Ok({ target, findings, summary: { failures, warnings } })
+  let failures = all_findings.iter().filter(fn(f) { f.level == Fail }).count()
+  let warnings = all_findings.iter().filter(fn(f) { f.level == Warn }).count()
+  Ok({ target, findings: all_findings, summary: { failures, warnings } })
 }

--- a/core/engine/engine.mbt
+++ b/core/engine/engine.mbt
@@ -77,7 +77,7 @@ pub fn scan(
           if visited.get(ref_key) is None {
             visited[ref_key] = true
             if depth < @papion.max_scan_depth &&
-              node_count < @papion.max_scan_nodes {
+              queue.length() < @papion.max_scan_nodes {
               match fetch(ref_.owner, ref_.repo, ref_.git_ref, ref_.path) {
                 Ok(yaml) => {
                   let child_chain = chain.copy()

--- a/core/engine/engine.mbt
+++ b/core/engine/engine.mbt
@@ -10,6 +10,13 @@ pub fn scan(
   target : @papion.ScanTarget,
   action_yml_yaml : String,
   policy : @papion.Policy,
+  resolve_ref_kind? : (String, String, String) -> @papion.RefKind = fn(
+    _owner,
+    _repo,
+    git_ref,
+  ) {
+    @rules.classify_ref(git_ref)
+  },
 ) -> Result[@papion.ScanResult, String] {
   let policy = match policy.normalized() {
     Ok(policy) => policy
@@ -22,7 +29,8 @@ pub fn scan(
   let refs = @parser.extract_refs(yml)
   let findings : Array[@papion.Finding] = []
   for ref_ in refs {
-    findings.append(@rules.evaluate(ref_, policy))
+    let ref_kind = resolve_ref_kind(ref_.owner, ref_.repo, ref_.git_ref)
+    findings.append(@rules.evaluate(ref_, ref_kind, policy))
   }
   let failures = findings.iter().filter(fn(f) { f.level == Fail }).count()
   let warnings = findings.iter().filter(fn(f) { f.level == Warn }).count()

--- a/core/engine/engine_test.mbt
+++ b/core/engine/engine_test.mbt
@@ -240,7 +240,11 @@ test "scan skips ref kind resolver when sha_pinning is false" {
     #|  steps:
     #|    - uses: actions/checkout@v4
   let mut calls = 0
-  let policy : @papion.Policy = { sha_pinning: false, allowed: [], disallowed: [] }
+  let policy : @papion.Policy = {
+    sha_pinning: false,
+    allowed: [],
+    disallowed: [],
+  }
   let result = scan(target, yaml_str, policy, resolve_ref_kind=fn(_, _, _) {
     calls = calls + 1
     ImmutableRelease

--- a/core/engine/engine_test.mbt
+++ b/core/engine/engine_test.mbt
@@ -187,6 +187,46 @@ test "scan result target matches input" {
 }
 
 ///|
+test "scan uses injected ref kind resolver" {
+  let target : @papion.ScanTarget = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "v4",
+  }
+  let yaml_str =
+    #|name: My Action
+    #|runs:
+    #|  using: composite
+    #|  steps:
+    #|    - uses: actions/checkout@v4
+  let mut calls = 0
+  let mut resolved_owner = ""
+  let mut resolved_repo = ""
+  let mut resolved_git_ref = ""
+  let result = scan(target, yaml_str, @papion.Policy::default(), resolve_ref_kind=fn(
+    owner,
+    repo,
+    git_ref,
+  ) {
+    calls = calls + 1
+    resolved_owner = owner
+    resolved_repo = repo
+    resolved_git_ref = git_ref
+    ImmutableRelease
+  })
+  match result {
+    Err(e) => fail("unexpected error: \{e}")
+    Ok(r) => {
+      assert_eq(calls, 1)
+      assert_eq(resolved_owner, "actions")
+      assert_eq(resolved_repo, "checkout")
+      assert_eq(resolved_git_ref, "v4")
+      assert_eq(r.findings, [])
+    }
+  }
+}
+
+///|
 test "scan normalizes policy patterns before evaluation" {
   let target : @papion.ScanTarget = {
     owner: "actions",

--- a/core/engine/engine_test.mbt
+++ b/core/engine/engine_test.mbt
@@ -227,6 +227,31 @@ test "scan uses injected ref kind resolver" {
 }
 
 ///|
+test "scan skips ref kind resolver when sha_pinning is false" {
+  let target : @papion.ScanTarget = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "v4",
+  }
+  let yaml_str =
+    #|name: My Action
+    #|runs:
+    #|  using: composite
+    #|  steps:
+    #|    - uses: actions/checkout@v4
+  let mut calls = 0
+  let policy : @papion.Policy = { sha_pinning: false, allowed: [], disallowed: [] }
+  let result = scan(target, yaml_str, policy, resolve_ref_kind=fn(_, _, _) {
+    calls = calls + 1
+    ImmutableRelease
+  })
+  match result {
+    Err(e) => fail("unexpected error: \{e}")
+    Ok(_) => assert_eq(calls, 0)
+  }
+}
+
+///|
 test "scan normalizes policy patterns before evaluation" {
   let target : @papion.ScanTarget = {
     owner: "actions",

--- a/core/engine/engine_test.mbt
+++ b/core/engine/engine_test.mbt
@@ -273,3 +273,330 @@ test "scan rejects overlong policy patterns" {
     Ok(_) => fail("expected Err for overlong policy pattern")
   }
 }
+
+// Helper: build a fetch table for recursive tests.
+// Each entry maps "owner/repo@ref" (or "owner/repo/path@ref") to a YAML string.
+
+///|
+fn make_fetch_table(
+  entries : Array[(String, String)],
+) -> (String, String, String, String?) -> Result[String, String] {
+  let table : Map[String, String] = {}
+  for entry in entries {
+    table[entry.0] = entry.1
+  }
+  fn(owner, repo, git_ref, path) {
+    let key = match path {
+      None => "\{owner}/\{repo}@\{git_ref}"
+      Some(p) => "\{owner}/\{repo}/\{p}@\{git_ref}"
+    }
+    match table.get(key) {
+      Some(yaml) => Ok(yaml)
+      None => Err("not found: \{key}")
+    }
+  }
+}
+
+///|
+test "recursive scan traverses direct dependency" {
+  let target : @papion.ScanTarget = {
+    owner: "org",
+    repo: "action-a",
+    git_ref: "v1",
+  }
+  let root_yaml =
+    #|name: Action A
+    #|runs:
+    #|  using: composite
+    #|  steps:
+    #|    - uses: org/action-b@v2
+  let dep_yaml =
+    #|name: Action B
+    #|runs:
+    #|  using: composite
+    #|  steps:
+    #|    - uses: third-party/unsafe@branch-name
+  let fetch = make_fetch_table([("org/action-b@v2", dep_yaml)])
+  let result = scan(
+    target,
+    root_yaml,
+    @papion.Policy::default(),
+    fetch_action_yml=Some(fetch),
+  )
+  match result {
+    Err(e) => fail("unexpected error: \{e}")
+    Ok(r) => {
+      assert_eq(r.summary.failures, 2)
+      // root finding: org/action-b@v2 (branch)
+      // transitive finding: third-party/unsafe@branch-name (branch)
+      let has_context = r.findings.iter().any(fn(f) { f.context is Some(_) })
+      assert_eq(has_context, true)
+      let transitive = r.findings
+        .iter()
+        .filter(fn(f) { f.context is Some(_) })
+        .collect()
+      assert_eq(transitive.length(), 1)
+      assert_eq(transitive[0].context, Some("org/action-b@v2"))
+    }
+  }
+}
+
+///|
+test "recursive scan shows full chain for deep dependency" {
+  let target : @papion.ScanTarget = {
+    owner: "org",
+    repo: "action-a",
+    git_ref: "v1",
+  }
+  let yaml_a =
+    #|name: Action A
+    #|runs:
+    #|  using: composite
+    #|  steps:
+    #|    - uses: org/action-b@v1
+  let yaml_b =
+    #|name: Action B
+    #|runs:
+    #|  using: composite
+    #|  steps:
+    #|    - uses: org/action-c@v1
+  let yaml_c =
+    #|name: Action C
+    #|runs:
+    #|  using: composite
+    #|  steps:
+    #|    - uses: third-party/leaf@main
+  let fetch = make_fetch_table([
+    ("org/action-b@v1", yaml_b),
+    ("org/action-c@v1", yaml_c),
+  ])
+  let result = scan(
+    target,
+    yaml_a,
+    @papion.Policy::default(),
+    fetch_action_yml=Some(fetch),
+  )
+  match result {
+    Err(e) => fail("unexpected error: \{e}")
+    Ok(r) => {
+      let deep = r.findings
+        .iter()
+        .filter(fn(f) {
+          match f.context {
+            Some(ctx) => ctx.contains(">")
+            None => false
+          }
+        })
+        .collect()
+      assert_eq(deep.length(), 1)
+      assert_eq(deep[0].context, Some("org/action-b@v1 > org/action-c@v1"))
+    }
+  }
+}
+
+///|
+test "recursive scan fetches shared dependency only once" {
+  let target : @papion.ScanTarget = {
+    owner: "org",
+    repo: "action-a",
+    git_ref: "v1",
+  }
+  let yaml_a =
+    #|name: Action A
+    #|runs:
+    #|  using: composite
+    #|  steps:
+    #|    - uses: org/action-b@v1
+    #|    - uses: org/action-c@v1
+  let yaml_b =
+    #|name: Action B
+    #|runs:
+    #|  using: composite
+    #|  steps:
+    #|    - uses: org/shared@v1
+  let yaml_c =
+    #|name: Action C
+    #|runs:
+    #|  using: composite
+    #|  steps:
+    #|    - uses: org/shared@v1
+  let yaml_shared =
+    #|name: Shared
+    #|runs:
+    #|  using: node20
+  let mut fetch_count = 0
+  fn fetch(owner, repo, git_ref, path) {
+    let key = match path {
+      None => "\{owner}/\{repo}@\{git_ref}"
+      Some(p) => "\{owner}/\{repo}/\{p}@\{git_ref}"
+    }
+    if key == "org/shared@v1" {
+      fetch_count = fetch_count + 1
+    }
+    let table = make_fetch_table([
+      ("org/action-b@v1", yaml_b),
+      ("org/action-c@v1", yaml_c),
+      ("org/shared@v1", yaml_shared),
+    ])
+    table(owner, repo, git_ref, path)
+  }
+
+  let result = scan(
+    target,
+    yaml_a,
+    @papion.Policy::default(),
+    fetch_action_yml=Some(fetch),
+  )
+  match result {
+    Err(e) => fail("unexpected error: \{e}")
+    Ok(_) => assert_eq(fetch_count, 1)
+  }
+}
+
+///|
+test "recursive scan terminates on simple cycle" {
+  let target : @papion.ScanTarget = {
+    owner: "org",
+    repo: "action-a",
+    git_ref: "v1",
+  }
+  let yaml_a =
+    #|name: Action A
+    #|runs:
+    #|  using: composite
+    #|  steps:
+    #|    - uses: org/action-b@v1
+  let yaml_b =
+    #|name: Action B
+    #|runs:
+    #|  using: composite
+    #|  steps:
+    #|    - uses: org/action-a@v1
+  let fetch = make_fetch_table([
+    ("org/action-b@v1", yaml_b),
+    ("org/action-a@v1", yaml_a),
+  ])
+  let result = scan(
+    target,
+    yaml_a,
+    @papion.Policy::default(),
+    fetch_action_yml=Some(fetch),
+  )
+  match result {
+    Err(e) => fail("unexpected error: \{e}")
+    Ok(r) => assert_eq(r.summary.failures > 0, true)
+  }
+}
+
+///|
+test "recursive scan terminates on longer cycle" {
+  let target : @papion.ScanTarget = {
+    owner: "org",
+    repo: "action-a",
+    git_ref: "v1",
+  }
+  let yaml_a =
+    #|name: A
+    #|runs:
+    #|  using: composite
+    #|  steps:
+    #|    - uses: org/action-b@v1
+  let yaml_b =
+    #|name: B
+    #|runs:
+    #|  using: composite
+    #|  steps:
+    #|    - uses: org/action-c@v1
+  let yaml_c =
+    #|name: C
+    #|runs:
+    #|  using: composite
+    #|  steps:
+    #|    - uses: org/action-a@v1
+  let fetch = make_fetch_table([
+    ("org/action-b@v1", yaml_b),
+    ("org/action-c@v1", yaml_c),
+    ("org/action-a@v1", yaml_a),
+  ])
+  let result = scan(
+    target,
+    yaml_a,
+    @papion.Policy::default(),
+    fetch_action_yml=Some(fetch),
+  )
+  match result {
+    Err(e) => fail("unexpected error: \{e}")
+    Ok(_) => ()
+  }
+}
+
+///|
+test "recursive scan without fetch callback processes root only" {
+  let target : @papion.ScanTarget = {
+    owner: "org",
+    repo: "action-a",
+    git_ref: "v1",
+  }
+  let yaml_a =
+    #|name: Action A
+    #|runs:
+    #|  using: composite
+    #|  steps:
+    #|    - uses: org/action-b@branch-ref
+  let result = scan(target, yaml_a, @papion.Policy::default())
+  match result {
+    Err(e) => fail("unexpected error: \{e}")
+    Ok(r) => {
+      assert_eq(r.summary.failures, 1)
+      assert_eq(r.findings[0].context, None)
+    }
+  }
+}
+
+///|
+test "recursive scan root parse error propagates" {
+  let target : @papion.ScanTarget = {
+    owner: "org",
+    repo: "action-a",
+    git_ref: "v1",
+  }
+  let result = scan(
+    target,
+    ":\t bad yaml",
+    @papion.Policy::default(),
+    fetch_action_yml=Some(make_fetch_table([])),
+  )
+  match result {
+    Err(_) => ()
+    Ok(_) => fail("expected error for invalid root YAML")
+  }
+}
+
+///|
+test "recursive scan transitive parse error is skipped" {
+  let target : @papion.ScanTarget = {
+    owner: "org",
+    repo: "action-a",
+    git_ref: "v1",
+  }
+  let yaml_a =
+    #|name: Action A
+    #|runs:
+    #|  using: composite
+    #|  steps:
+    #|    - uses: org/action-b@v1
+  let fetch = make_fetch_table([("org/action-b@v1", ":\t invalid")])
+  let result = scan(
+    target,
+    yaml_a,
+    @papion.Policy::default(),
+    fetch_action_yml=Some(fetch),
+  )
+  match result {
+    Err(e) => fail("unexpected error: \{e}")
+    Ok(r) => {
+      assert_eq(r.summary.failures, 1)
+      assert_eq(r.findings[0].context, None)
+    }
+  }
+}

--- a/core/engine/pkg.generated.mbti
+++ b/core/engine/pkg.generated.mbti
@@ -6,7 +6,7 @@ import {
 }
 
 // Values
-pub fn scan(@papion.ScanTarget, String, @papion.Policy, resolve_ref_kind? : (String, String, String) -> @papion.RefKind) -> Result[@papion.ScanResult, String]
+pub fn scan(@papion.ScanTarget, String, @papion.Policy, resolve_ref_kind? : (String, String, String) -> @papion.RefKind, fetch_action_yml? : ((String, String, String, String?) -> Result[String, String])?) -> Result[@papion.ScanResult, String]
 
 // Errors
 

--- a/core/engine/pkg.generated.mbti
+++ b/core/engine/pkg.generated.mbti
@@ -6,7 +6,7 @@ import {
 }
 
 // Values
-pub fn scan(@papion.ScanTarget, String, @papion.Policy) -> Result[@papion.ScanResult, String]
+pub fn scan(@papion.ScanTarget, String, @papion.Policy, resolve_ref_kind? : (String, String, String) -> @papion.RefKind) -> Result[@papion.ScanResult, String]
 
 // Errors
 

--- a/core/native/github.mbt
+++ b/core/native/github.mbt
@@ -67,6 +67,38 @@ fn extract_default_branch_field(
 }
 
 ///|
+fn extract_release_immutable_field(
+  body : String,
+  owner : String,
+  repo : String,
+  tag : String,
+) -> Result[Bool, (Int, String)] {
+  let json = try? @json.parse(body)
+  let json = match json {
+    Ok(json) => json
+    Err(err) =>
+      return Err(
+        (
+          0,
+          "failed to parse GitHub release response for \{owner}/\{repo}@\{tag}: \{err}",
+        ),
+      )
+  }
+  match json {
+    { "immutable": true, .. } => Ok(true)
+    { "immutable": false, .. } => Ok(false)
+    { "immutable": _, .. } =>
+      Err(
+        (
+          0,
+          "GitHub release response for \{owner}/\{repo}@\{tag} did not contain a boolean immutable field",
+        ),
+      )
+    _ => Ok(false)
+  }
+}
+
+///|
 fn extract_matching_refs_field(
   body : String,
   owner : String,
@@ -178,6 +210,50 @@ fn github_repo_url(
     Ok(url.to_string())
   } catch {
     _ => Err((0, "failed to build GitHub repository URL for \{owner}/\{repo}"))
+  }
+}
+
+///|
+fn github_release_by_tag_url(
+  owner : String,
+  repo : String,
+  tag : String,
+) -> Result[String, (Int, String)] {
+  try {
+    let url = @url.Url::parse("https://api.github.com")
+    let enc_owner = @cli.percent_encode_path_component(owner)
+    let enc_repo = @cli.percent_encode_path_component(repo)
+    let enc_tag = tag
+      .split("/")
+      .map(fn(segment) {
+        @cli.percent_encode_path_component(segment.to_string())
+      })
+      .to_array()
+      .join("/")
+    url.set_pathname("/repos/\{enc_owner}/\{enc_repo}/releases/tags/\{enc_tag}")
+    Ok(url.to_string())
+  } catch {
+    _ =>
+      Err((0, "failed to build GitHub release URL for \{owner}/\{repo}@\{tag}"))
+  }
+}
+
+///|
+fn github_commit_url(
+  owner : String,
+  repo : String,
+  sha : String,
+) -> Result[String, (Int, String)] {
+  try {
+    let url = @url.Url::parse("https://api.github.com")
+    let enc_owner = @cli.percent_encode_path_component(owner)
+    let enc_repo = @cli.percent_encode_path_component(repo)
+    let enc_sha = @cli.percent_encode_path_component(sha)
+    url.set_pathname("/repos/\{enc_owner}/\{enc_repo}/git/commits/\{enc_sha}")
+    Ok(url.to_string())
+  } catch {
+    _ =>
+      Err((0, "failed to build GitHub commit URL for \{owner}/\{repo}@\{sha}"))
   }
 }
 
@@ -344,6 +420,142 @@ fn fetch_default_branch(
     }
     match request {
       Ok(branch) => result = Ok(branch)
+      Err(err) => result = Err(err)
+    }
+  })
+  result
+}
+
+///|
+fn fetch_release_by_tag(
+  owner : String,
+  repo : String,
+  tag : String,
+) -> Result[Bool, (Int, String)] {
+  let url = match github_release_by_tag_url(owner, repo, tag) {
+    Ok(url) => url
+    Err(err) => return Err(err)
+  }
+  let mut result : Result[Bool, (Int, String)] = Err(
+    (0, "request was not executed"),
+  )
+  @async.run_async_main(() => {
+    let headers = {
+      "User-Agent": @papion.cli_user_agent(),
+      "Accept": "application/vnd.github+json",
+    }
+    if github_token() is Some(token) {
+      headers["Authorization"] = "Bearer \{token}"
+    }
+    let request : Result[Bool, (Int, String)] = try {
+      let immutable = @async.retry(
+        @async.ExponentialDelay(initial=1000, factor=2.0, maximum=10000),
+        max_retry=3,
+        fatal_error=fn(err) {
+          match err {
+            HttpError((code, _)) =>
+              code == 0 || (code >= 400 && code < 500 && code != 429)
+            _ => false
+          }
+        },
+        () => {
+          let pair = @async.with_timeout(30000, () => @http.get(url, headers~))
+          let (response, body) = pair
+          match response.code {
+            200 =>
+              match
+                extract_release_immutable_field(body.text(), owner, repo, tag) {
+                Ok(immutable) => immutable
+                Err(err) => raise HttpError(err)
+              }
+            404 => false
+            _ =>
+              raise HttpError(
+                (
+                  response.code,
+                  "failed to fetch release metadata for \{owner}/\{repo}@\{tag} (\{response.code} \{response.reason})",
+                ),
+              )
+          }
+        },
+      )
+      Ok(immutable)
+    } catch {
+      HttpError(err) => Err(err)
+      err =>
+        Err(
+          (
+            0,
+            "failed to fetch release metadata for \{owner}/\{repo}@\{tag}: \{err}",
+          ),
+        )
+    }
+    match request {
+      Ok(immutable) => result = Ok(immutable)
+      Err(err) => result = Err(err)
+    }
+  })
+  result
+}
+
+///|
+fn fetch_commit_exists(
+  owner : String,
+  repo : String,
+  sha : String,
+) -> Result[Bool, (Int, String)] {
+  let url = match github_commit_url(owner, repo, sha) {
+    Ok(url) => url
+    Err(err) => return Err(err)
+  }
+  let mut result : Result[Bool, (Int, String)] = Err(
+    (0, "request was not executed"),
+  )
+  @async.run_async_main(() => {
+    let headers = {
+      "User-Agent": @papion.cli_user_agent(),
+      "Accept": "application/vnd.github+json",
+    }
+    if github_token() is Some(token) {
+      headers["Authorization"] = "Bearer \{token}"
+    }
+    let request : Result[Bool, (Int, String)] = try {
+      let exists = @async.retry(
+        @async.ExponentialDelay(initial=1000, factor=2.0, maximum=10000),
+        max_retry=3,
+        fatal_error=fn(err) {
+          match err {
+            HttpError((code, _)) =>
+              code == 0 || (code >= 400 && code < 500 && code != 429)
+            _ => false
+          }
+        },
+        () => {
+          let pair = @async.with_timeout(30000, () => @http.get(url, headers~))
+          let (response, _) = pair
+          match response.code {
+            200 => true
+            404 => false
+            _ =>
+              raise HttpError(
+                (
+                  response.code,
+                  "failed to verify commit SHA for \{owner}/\{repo}@\{sha} (\{response.code} \{response.reason})",
+                ),
+              )
+          }
+        },
+      )
+      Ok(exists)
+    } catch {
+      HttpError(err) => Err(err)
+      err =>
+        Err(
+          (0, "failed to verify commit SHA for \{owner}/\{repo}@\{sha}: \{err}"),
+        )
+    }
+    match request {
+      Ok(exists) => result = Ok(exists)
       Err(err) => result = Err(err)
     }
   })
@@ -581,5 +793,23 @@ pub fn fetch_action_yml(
   match action_yml {
     Ok(action_yml) => Ok((action_yml, resolved_git_ref))
     Err(_) => Err("GitHub action file is not valid UTF-8")
+  }
+}
+
+///|
+pub fn resolve_ref_kind_via_api(
+  owner : String,
+  repo : String,
+  git_ref : String,
+) -> @papion.RefKind {
+  if @rules.classify_ref(git_ref) == Sha {
+    match fetch_commit_exists(owner, repo, git_ref) {
+      Ok(true) => return Sha
+      _ => return Branch
+    }
+  }
+  match fetch_release_by_tag(owner, repo, git_ref) {
+    Ok(true) => ImmutableRelease
+    _ => Branch
   }
 }

--- a/core/native/github.mbt
+++ b/core/native/github.mbt
@@ -223,13 +223,7 @@ fn github_release_by_tag_url(
     let url = @url.Url::parse("https://api.github.com")
     let enc_owner = @cli.percent_encode_path_component(owner)
     let enc_repo = @cli.percent_encode_path_component(repo)
-    let enc_tag = tag
-      .split("/")
-      .map(fn(segment) {
-        @cli.percent_encode_path_component(segment.to_string())
-      })
-      .to_array()
-      .join("/")
+    let enc_tag = @cli.percent_encode_path_component(tag)
     url.set_pathname("/repos/\{enc_owner}/\{enc_repo}/releases/tags/\{enc_tag}")
     Ok(url.to_string())
   } catch {

--- a/core/native/main.mbt
+++ b/core/native/main.mbt
@@ -29,5 +29,10 @@ fn main {
 
 ///|
 fn run(args : Array[String]) -> Result[@cli.RunOutcome, @cli.CliError] {
-  @cli.run_with_host(args, load_config, fetch_action_yml)
+  @cli.run_with_host(
+    args,
+    load_config,
+    fetch_action_yml,
+    resolve_ref_kind=resolve_ref_kind_via_api,
+  )
 }

--- a/core/native/moon.pkg
+++ b/core/native/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "maruloop/papion/cli",
   "maruloop/papion",
+  "maruloop/papion/rules",
   "moonbitlang/async",
   "moonbitlang/async/http",
   "moonbitlang/core/buffer",

--- a/core/native/native_wbtest.mbt
+++ b/core/native/native_wbtest.mbt
@@ -123,6 +123,29 @@ test "github_repo_url encodes owner and repo path segments" {
 }
 
 ///|
+test "github_release_by_tag_url encodes owner repo and tag path segments" {
+  let url = match
+    github_release_by_tag_url("maru/loop", "pa pion", "v1.0.0/rc 1") {
+    Ok(url) => url
+    Err(err) => fail(err.1)
+  }
+  assert_eq(
+    url, "https://api.github.com/repos/maru%2Floop/pa%20pion/releases/tags/v1.0.0/rc%201",
+  )
+}
+
+///|
+test "github_commit_url encodes owner repo and sha path segments" {
+  let url = match github_commit_url("maru/loop", "pa pion", "abc/123") {
+    Ok(url) => url
+    Err(err) => fail(err.1)
+  }
+  assert_eq(
+    url, "https://api.github.com/repos/maru%2Floop/pa%20pion/git/commits/abc%2F123",
+  )
+}
+
+///|
 test "extract_matching_refs_field returns stripped refs" {
   assert_eq(
     extract_matching_refs_field(
@@ -209,6 +232,62 @@ test "extract_default_branch_field errors when default_branch is not string" {
     Err(
       (
         0, "GitHub repository response for octocat/hello-world did not contain a string default_branch field",
+      ),
+    ),
+  )
+}
+
+///|
+test "extract_release_immutable_field returns true when immutable is true" {
+  assert_eq(
+    extract_release_immutable_field(
+      "{\"immutable\":true}", "octocat", "hello-world", "v1",
+    ),
+    Ok(true),
+  )
+}
+
+///|
+test "extract_release_immutable_field returns false when immutable is false" {
+  assert_eq(
+    extract_release_immutable_field(
+      "{\"immutable\":false}", "octocat", "hello-world", "v1",
+    ),
+    Ok(false),
+  )
+}
+
+///|
+test "extract_release_immutable_field returns false when immutable missing" {
+  assert_eq(
+    extract_release_immutable_field(
+      "{\"tag_name\":\"v1\"}", "octocat", "hello-world", "v1",
+    ),
+    Ok(false),
+  )
+}
+
+///|
+test "extract_release_immutable_field errors when immutable is not bool" {
+  assert_eq(
+    extract_release_immutable_field(
+      "{\"immutable\":123}", "octocat", "hello-world", "v1",
+    ),
+    Err(
+      (
+        0, "GitHub release response for octocat/hello-world@v1 did not contain a boolean immutable field",
+      ),
+    ),
+  )
+}
+
+///|
+test "extract_release_immutable_field errors on parse failure" {
+  assert_eq(
+    extract_release_immutable_field("{", "octocat", "hello-world", "v1"),
+    Err(
+      (
+        0, "failed to parse GitHub release response for octocat/hello-world@v1: Unexpected end of file",
       ),
     ),
   )

--- a/core/native/native_wbtest.mbt
+++ b/core/native/native_wbtest.mbt
@@ -130,7 +130,7 @@ test "github_release_by_tag_url encodes owner repo and tag path segments" {
     Err(err) => fail(err.1)
   }
   assert_eq(
-    url, "https://api.github.com/repos/maru%2Floop/pa%20pion/releases/tags/v1.0.0/rc%201",
+    url, "https://api.github.com/repos/maru%2Floop/pa%20pion/releases/tags/v1.0.0%2Frc%201",
   )
 }
 

--- a/core/native/pkg.generated.mbti
+++ b/core/native/pkg.generated.mbti
@@ -10,6 +10,8 @@ pub fn fetch_action_yml(String, String, String?, String?, Bool) -> Result[(Strin
 
 pub fn load_config(String?) -> Result[@papion.Policy, String]
 
+pub fn resolve_ref_kind_via_api(String, String, String) -> @papion.RefKind
+
 // Errors
 
 // Types and methods

--- a/core/papion.mbt
+++ b/core/papion.mbt
@@ -5,6 +5,12 @@ pub let version : String = "0.1.0"
 pub let max_policy_pattern_len : Int = 256
 
 ///|
+pub let max_scan_depth : Int = 10
+
+///|
+pub let max_scan_nodes : Int = 100
+
+///|
 pub fn cli_user_agent() -> String {
   "papion/\{version} (+https://github.com/maruloop/papion)"
 }

--- a/core/papion.mbt
+++ b/core/papion.mbt
@@ -44,6 +44,7 @@ pub(all) enum RefKind {
   Sha
   Tag
   Branch
+  ImmutableRelease
 } derive(Debug, Eq, ToJson, FromJson)
 
 ///|

--- a/core/papion_test.mbt
+++ b/core/papion_test.mbt
@@ -29,15 +29,19 @@ test "RefKind json roundtrip" {
   let sha : @papion.RefKind = Sha
   let tag : @papion.RefKind = Tag
   let branch : @papion.RefKind = Branch
+  let immutable_release : @papion.RefKind = ImmutableRelease
   let s_json = @json.parse(sha.to_json().stringify())
   let t_json = @json.parse(tag.to_json().stringify())
   let b_json = @json.parse(branch.to_json().stringify())
+  let i_json = @json.parse(immutable_release.to_json().stringify())
   let s_back : @papion.RefKind = @json.from_json(s_json)
   let t_back : @papion.RefKind = @json.from_json(t_json)
   let b_back : @papion.RefKind = @json.from_json(b_json)
+  let i_back : @papion.RefKind = @json.from_json(i_json)
   assert_eq(sha, s_back)
   assert_eq(tag, t_back)
   assert_eq(branch, b_back)
+  assert_eq(immutable_release, i_back)
 }
 
 ///|

--- a/core/pkg.generated.mbti
+++ b/core/pkg.generated.mbti
@@ -11,6 +11,10 @@ pub fn cli_user_agent() -> String
 
 pub let max_policy_pattern_len : Int
 
+pub let max_scan_depth : Int
+
+pub let max_scan_nodes : Int
+
 pub let version : String
 
 // Errors

--- a/core/pkg.generated.mbti
+++ b/core/pkg.generated.mbti
@@ -67,6 +67,7 @@ pub(all) enum RefKind {
   Sha
   Tag
   Branch
+  ImmutableRelease
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub impl Show for RefKind
 

--- a/core/rules/pkg.generated.mbti
+++ b/core/rules/pkg.generated.mbti
@@ -10,11 +10,11 @@ pub fn check_allowed(@papion.ActionRef, @papion.Policy) -> Array[@papion.Finding
 
 pub fn check_disallowed(@papion.ActionRef, @papion.Policy) -> Array[@papion.Finding]
 
-pub fn check_sha_pinning(@papion.ActionRef, @papion.Policy) -> Array[@papion.Finding]
+pub fn check_sha_pinning(@papion.ActionRef, @papion.RefKind, @papion.Policy) -> Array[@papion.Finding]
 
 pub fn classify_ref(String) -> @papion.RefKind
 
-pub fn evaluate(@papion.ActionRef, @papion.Policy) -> Array[@papion.Finding]
+pub fn evaluate(@papion.ActionRef, @papion.RefKind, @papion.Policy) -> Array[@papion.Finding]
 
 // Errors
 

--- a/core/rules/rules.mbt
+++ b/core/rules/rules.mbt
@@ -35,13 +35,15 @@ pub fn classify_ref(git_ref : String) -> @papion.RefKind {
 /// rule is disabled or the ref is already pinned.
 pub fn check_sha_pinning(
   action_ref : @papion.ActionRef,
+  ref_kind : @papion.RefKind,
   policy : @papion.Policy,
 ) -> Array[@papion.Finding] {
   if !policy.sha_pinning {
     return []
   }
-  if classify_ref(action_ref.git_ref) == Sha {
-    return []
+  match ref_kind {
+    Sha | ImmutableRelease => return []
+    _ => ()
   }
   [
     {
@@ -49,7 +51,7 @@ pub fn check_sha_pinning(
       rule: "sha-pinning",
       target: format_target(action_ref),
       context: None,
-      message: "action ref is not pinned to a SHA — use a 40-character hex commit SHA instead of a tag or branch name",
+      message: "action ref is not pinned to a SHA or immutable release",
       suggestion: None,
     },
   ]
@@ -111,10 +113,11 @@ pub fn check_disallowed(
 /// All findings are collected — rules are independent.
 pub fn evaluate(
   action_ref : @papion.ActionRef,
+  ref_kind : @papion.RefKind,
   policy : @papion.Policy,
 ) -> Array[@papion.Finding] {
   let findings : Array[@papion.Finding] = []
-  findings.append(check_sha_pinning(action_ref, policy))
+  findings.append(check_sha_pinning(action_ref, ref_kind, policy))
   findings.append(check_allowed(action_ref, policy))
   findings.append(check_disallowed(action_ref, policy))
   findings

--- a/core/rules/rules.mbt
+++ b/core/rules/rules.mbt
@@ -52,7 +52,9 @@ pub fn check_sha_pinning(
       target: format_target(action_ref),
       context: None,
       message: "action ref is not pinned to a SHA or immutable release",
-      suggestion: None,
+      suggestion: Some(
+        "pin to a full commit SHA (e.g. @abc123...) or an immutable release tag",
+      ),
     },
   ]
 }

--- a/core/rules/rules_test.mbt
+++ b/core/rules/rules_test.mbt
@@ -52,7 +52,7 @@ test "check_sha_pinning SHA ref passes" {
     path: None,
   }
   let policy = @papion.Policy::default()
-  assert_eq(check_sha_pinning(action_ref, policy), [])
+  assert_eq(check_sha_pinning(action_ref, Sha, policy), [])
 }
 
 ///|
@@ -64,11 +64,45 @@ test "check_sha_pinning non-SHA ref fails" {
     path: None,
   }
   let policy = @papion.Policy::default()
-  let findings = check_sha_pinning(action_ref, policy)
+  let findings = check_sha_pinning(action_ref, Branch, policy)
   assert_eq(findings.length(), 1)
   assert_eq(findings[0].level, @papion.FindingLevel::Fail)
   assert_eq(findings[0].rule, "sha-pinning")
   assert_eq(findings[0].target, "actions/checkout@v4")
+  assert_eq(
+    findings[0].message,
+    "action ref is not pinned to a SHA or immutable release",
+  )
+}
+
+///|
+test "check_sha_pinning immutable release passes" {
+  let action_ref : @papion.ActionRef = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "v4",
+    path: None,
+  }
+  let policy = @papion.Policy::default()
+  assert_eq(check_sha_pinning(action_ref, ImmutableRelease, policy), [])
+}
+
+///|
+test "check_sha_pinning tag ref fails" {
+  let action_ref : @papion.ActionRef = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "v4",
+    path: None,
+  }
+  let policy = @papion.Policy::default()
+  let findings = check_sha_pinning(action_ref, Tag, policy)
+  assert_eq(findings.length(), 1)
+  assert_eq(findings[0].rule, "sha-pinning")
+  assert_eq(
+    findings[0].message,
+    "action ref is not pinned to a SHA or immutable release",
+  )
 }
 
 ///|
@@ -84,7 +118,7 @@ test "check_sha_pinning disabled skips" {
     allowed: [],
     disallowed: [],
   }
-  assert_eq(check_sha_pinning(action_ref, policy), [])
+  assert_eq(check_sha_pinning(action_ref, Branch, policy), [])
 }
 
 ///|
@@ -184,7 +218,7 @@ test "evaluate SHA ref empty policy produces no findings" {
     path: None,
   }
   let policy = @papion.Policy::default()
-  assert_eq(evaluate(action_ref, policy), [])
+  assert_eq(evaluate(action_ref, Sha, policy), [])
 }
 
 ///|
@@ -196,9 +230,25 @@ test "evaluate non-SHA ref default policy produces sha-pinning finding" {
     path: None,
   }
   let policy = @papion.Policy::default()
-  let findings = evaluate(action_ref, policy)
+  let findings = evaluate(action_ref, Branch, policy)
   assert_eq(findings.length(), 1)
   assert_eq(findings[0].rule, "sha-pinning")
+  assert_eq(
+    findings[0].message,
+    "action ref is not pinned to a SHA or immutable release",
+  )
+}
+
+///|
+test "evaluate immutable release produces no sha-pinning finding" {
+  let action_ref : @papion.ActionRef = {
+    owner: "actions",
+    repo: "checkout",
+    git_ref: "v4",
+    path: None,
+  }
+  let policy = @papion.Policy::default()
+  assert_eq(evaluate(action_ref, ImmutableRelease, policy), [])
 }
 
 ///|
@@ -214,7 +264,7 @@ test "evaluate non-SHA ref not in allowed list produces two findings" {
     allowed: ["github/*"],
     disallowed: [],
   }
-  let findings = evaluate(action_ref, policy)
+  let findings = evaluate(action_ref, Branch, policy)
   assert_eq(findings.length(), 2)
   assert_eq(findings[0].rule, "sha-pinning")
   assert_eq(findings[1].rule, "allowed-list")
@@ -233,7 +283,7 @@ test "evaluate action in both allowed and disallowed produces disallowed finding
     allowed: ["actions/*"],
     disallowed: ["actions/*"],
   }
-  let findings = evaluate(action_ref, policy)
+  let findings = evaluate(action_ref, Sha, policy)
   assert_eq(findings.length(), 1)
   assert_eq(findings[0].rule, "disallowed-list")
 }
@@ -247,7 +297,7 @@ test "check_sha_pinning with path includes path in target" {
     path: Some("deploy"),
   }
   let policy = @papion.Policy::default()
-  let findings = check_sha_pinning(action_ref, policy)
+  let findings = check_sha_pinning(action_ref, Branch, policy)
   assert_eq(findings.length(), 1)
   assert_eq(findings[0].target, "myorg/actions/deploy@v2")
 }
@@ -265,7 +315,7 @@ test "evaluate with path includes path in finding target" {
     allowed: ["github/*"],
     disallowed: [],
   }
-  let findings = evaluate(action_ref, policy)
+  let findings = evaluate(action_ref, Sha, policy)
   assert_eq(findings.length(), 1)
   assert_eq(findings[0].rule, "allowed-list")
   assert_eq(
@@ -287,5 +337,5 @@ test "evaluate all passing produces no findings" {
     allowed: ["actions/*"],
     disallowed: ["bad-org/*"],
   }
-  assert_eq(evaluate(action_ref, policy), [])
+  assert_eq(evaluate(action_ref, Sha, policy), [])
 }

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -532,6 +532,36 @@ Adopt the fourth option — fetch only the single file via the GitHub Contents A
 * Very deep slash-containing refs in pasted GitHub tree URLs may still fail native fallback resolution today; widening the cap remains an explicit future adjustment if real usage justifies the extra requests
 * The CLI host layer is split into target-aware packages so target-specific dependencies are represented structurally instead of through keepalive references.
 
+### Ref-kind resolution boundary
+
+Papion now treats ref-kind resolution as a host responsibility rather than a pure rules concern.
+
+The decision is:
+
+* `core/rules` receives `RefKind` as input data and stays pure
+* `core/engine.scan` accepts an injected `resolve_ref_kind` callback with a pure `classify_ref` fallback
+* native hosts may use GitHub API calls to refine that classification before evaluation
+
+This keeps the core contract honest:
+
+* pure and WASM environments can still classify refs structurally with no I/O
+* native hosts can verify whether a 40-character hex string actually exists as a commit SHA
+* native hosts can treat immutable GitHub releases as equivalent to SHA pins for policy evaluation
+
+### Immutable releases as SHA-equivalent pins
+
+Papion's `sha-pinning` rule now accepts either:
+
+* a verified commit SHA
+* an immutable GitHub release tag
+
+On native targets, the host checks:
+
+* `git/commits/{sha}` to verify that SHA-like refs really exist
+* `releases/tags/{tag}` and its `immutable` field to recognize immutable releases
+
+If either API check fails, the host fails closed and reports the ref to the pure rules layer as `Branch`, so Papion never grants a pass based on an unverifiable ref.
+
 ### CLI package boundaries
 
 The CLI is packaged as:

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -574,6 +574,46 @@ This lets MoonBit's package-level `unused_package` checks reflect real dependenc
 
 ---
 
+## Decision 20: Recursive transitive scanning strategy
+
+### Context
+
+Composite GitHub Actions can depend on other composite actions via `uses:` steps. A security scanner that only inspects the root `action.yml` misses transitive dependencies, which may contain unpinned refs or disallowed actions.
+
+### Options
+
+1. Add a separate `scan_recursive` function alongside `scan`
+2. Extend `scan` with an optional `fetch_action_yml~` callback; recursive mode is enabled automatically when the host provides it
+3. Add a `--recursive` CLI flag and have the CLI opt into recursion
+
+### Decision
+
+Adopt option 2: extend the existing `scan` function with an optional `fetch_action_yml~` labeled parameter.
+
+* When `fetch_action_yml~` is `None` (default, e.g. WASM without host fetch), `scan` processes only the root action — identical to prior behaviour.
+* When `fetch_action_yml~` is `Some(fetch)` (native CLI), `scan` performs BFS traversal of all transitive composite-action dependencies automatically — no separate function, no CLI flag.
+* The native `run_with_host` always passes a `fetch_action_yml` adapter that strips `allow_ref_fallback` (always `false` for transitive deps — the ref comes directly from the `uses:` field, not from user input).
+
+Option 1 was rejected because it duplicates the parse-extract-evaluate pipeline and creates two entry points with diverging behaviour. Option 3 was rejected because transitive scanning is the whole point of the tool — an opt-out model suits an advanced escape hatch, but opt-in creates friction and risks the common case being under-secured.
+
+### BFS traversal safeguards
+
+* Visited set keyed by `owner/repo[/path]@ref` — prevents re-fetching cycles
+* `max_scan_depth = 10` — maximum depth before a branch is abandoned
+* `max_scan_nodes = 100` — maximum total nodes processed; no new children are enqueued past this limit
+* Root parse failures → `Err`; transitive parse failures → node silently skipped
+* Fetch errors → node silently skipped (best-effort)
+
+### Dependency chain context
+
+Transitive findings carry a `context` field with the full dependency chain from the scanned root, e.g. `"org/action-b@v1 > org/action-c@v1"`. Root findings have `context = None`. This gives users the complete path to understand where a transitive issue originated.
+
+### resolve_ref_kind integration
+
+The same `resolve_ref_kind` callback (introduced in Decision 19) applies to every ref encountered during traversal, including transitive ones. Transitive dependencies receive the same SHA verification and immutable-release checks as direct dependencies.
+
+---
+
 ## Final Architecture Summary
 
 Papion is:


### PR DESCRIPTION
Supersedes #50.

## Summary

- Extends `engine.scan` with an optional `fetch_action_yml?` callback enabling BFS traversal of composite action transitive dependencies
- Always-on for native CLI — no `--recursive` flag; WASM gets root-only scan when callback is absent
- Integrates `resolve_ref_kind` for transitive refs (fixes PR #50 gap where transitive deps bypassed SHA/immutable verification)
- Full dependency chain context on findings: `"via org/action-b@v1 > org/action-c@v1"`
- Single `scan` function replaces the separate `scan_recursive` from PR #50
- Bounded: `max_scan_depth = 10`, `max_scan_nodes = 100` (keyed on scheduled queue length), visited-set cycle detection
- `resolve_ref_kind` skipped when `policy.sha_pinning = false` — avoids unnecessary API calls

## Changes

- `core/papion.mbt` — `max_scan_depth`, `max_scan_nodes` constants
- `core/engine/engine.mbt` — BFS-capable `scan` with `action_ref_key` helper
- `core/engine/engine_test.mbt` — 9 new tests: transitive chain, full chain context, shared dep fetched once, simple cycle, longer cycle, no-fetch-callback root-only, root parse error, transitive parse error skipped, resolver skipped when sha_pinning=false
- `core/cli/run.mbt` — always passes fetch adapter to engine
- `core/engine/README.mbt.md` — updated API and behaviour docs
- `docs/adr.md` — Decision 20

## Depends on

PR #46 (immutable releases / SHA verification). Requires #46 to merge first.

## Test plan

- [x] `moon fmt --check` passes
- [x] `moon test --deny-warn` — 168 tests pass
- [x] `moon test --target native --deny-warn` — 204 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)