### PR TITLE
feat(native): cache ref-kind API lookups per scan invocation

### DIFF
--- a/core/native/github.mbt
+++ b/core/native/github.mbt
@@ -683,3 +683,26 @@ pub fn resolve_ref_kind_via_api(
     git_ref, fetch_commit_exists, fetch_release_by_tag, owner, repo,
   )
 }
+
+///|
+fn cached_ref_kind_resolver_with(
+  api : (String, String, String) -> @papion.RefKind,
+) -> (String, String, String) -> @papion.RefKind {
+  let cache : Map[String, @papion.RefKind] = {}
+  fn(owner, repo, git_ref) {
+    let key = "\{owner.to_lower()}/\{repo.to_lower()}@\{git_ref}"
+    match cache.get(key) {
+      Some(kind) => kind
+      None => {
+        let kind = api(owner, repo, git_ref)
+        cache[key] = kind
+        kind
+      }
+    }
+  }
+}
+
+///|
+pub fn cached_ref_kind_resolver() -> (String, String, String) -> @papion.RefKind {
+  cached_ref_kind_resolver_with(resolve_ref_kind_via_api)
+}

--- a/core/native/github.mbt
+++ b/core/native/github.mbt
@@ -703,6 +703,6 @@ fn cached_ref_kind_resolver_with(
 }
 
 ///|
-pub fn cached_ref_kind_resolver() -> (String, String, String) -> @papion.RefKind {
+fn cached_ref_kind_resolver() -> (String, String, String) -> @papion.RefKind {
   cached_ref_kind_resolver_with(resolve_ref_kind_via_api)
 }

--- a/core/native/main.mbt
+++ b/core/native/main.mbt
@@ -33,6 +33,6 @@ fn run(args : Array[String]) -> Result[@cli.RunOutcome, @cli.CliError] {
     args,
     load_config,
     fetch_action_yml,
-    resolve_ref_kind=resolve_ref_kind_via_api,
+    resolve_ref_kind=cached_ref_kind_resolver(),
   )
 }

--- a/core/native/native_wbtest.mbt
+++ b/core/native/native_wbtest.mbt
@@ -521,3 +521,58 @@ test "resolve_ref_kind_impl: non-sha ref + release error => Branch" {
     Branch,
   )
 }
+
+///|
+test "cached_ref_kind_resolver_with: same key hits api only once" {
+  let mut call_count = 0
+  let api : (String, String, String) -> @papion.RefKind = fn(
+    _owner,
+    _repo,
+    _git_ref,
+  ) {
+    call_count = call_count + 1
+    ImmutableRelease
+  }
+  let resolver = cached_ref_kind_resolver_with(api)
+  let r1 = resolver("octocat", "hello-world", "v1.0.0")
+  let r2 = resolver("octocat", "hello-world", "v1.0.0")
+  assert_eq(call_count, 1)
+  assert_eq(r1, ImmutableRelease)
+  assert_eq(r2, ImmutableRelease)
+}
+
+///|
+test "cached_ref_kind_resolver_with: different keys each call api" {
+  let mut call_count = 0
+  let api : (String, String, String) -> @papion.RefKind = fn(
+    _owner,
+    _repo,
+    _git_ref,
+  ) {
+    call_count = call_count + 1
+    Branch
+  }
+  let resolver = cached_ref_kind_resolver_with(api)
+  ignore(resolver("octocat", "hello-world", "v1.0.0"))
+  ignore(resolver("octocat", "hello-world", "v2.0.0"))
+  assert_eq(call_count, 2)
+}
+
+///|
+test "cached_ref_kind_resolver_with: owner/repo case-insensitive" {
+  let mut call_count = 0
+  let api : (String, String, String) -> @papion.RefKind = fn(
+    _owner,
+    _repo,
+    _git_ref,
+  ) {
+    call_count = call_count + 1
+    Sha
+  }
+  let resolver = cached_ref_kind_resolver_with(api)
+  let r1 = resolver("Actions", "Checkout", "v4")
+  let r2 = resolver("actions", "checkout", "v4")
+  assert_eq(call_count, 1)
+  assert_eq(r1, Sha)
+  assert_eq(r2, Sha)
+}


### PR DESCRIPTION
## Summary

- Wraps `resolve_ref_kind_via_api` in a per-`run()` in-memory cache so the same `owner/repo@ref` never triggers more than one GitHub API request per scan
- Owner and repo are lowercased for cache key lookup (GitHub is case-insensitive); `git_ref` is preserved as-is (tags/branches are case-sensitive)
- `cached_ref_kind_resolver_with(api)` accepts an injectable API function for unit testing without hitting GitHub
- `cached_ref_kind_resolver()` is the production convenience wrapper wired into `main.mbt`

Closes #53

## Test plan

- [x] `cached_ref_kind_resolver_with: same key hits api only once` — API called exactly once for repeated identical args
- [x] `cached_ref_kind_resolver_with: different keys each call api` — distinct refs each trigger their own call
- [x] `cached_ref_kind_resolver_with: owner/repo case-insensitive` — `Actions/Checkout` and `actions/checkout` share one cache entry
- [x] `moon test --deny-warn` — 220 tests, all passing
- [x] `moon test --target native --deny-warn` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)