### PR TITLE
fix(ci): harden setup-moonbit action installs

### DIFF
--- a/.github/actions/setup-moonbit/action.yml
+++ b/.github/actions/setup-moonbit/action.yml
@@ -17,6 +17,7 @@ runs:
           echo "::error::setup-moonbit requires an explicit MoonBit version"
           exit 1
         fi
+        encoded_version="${version//+/%2B}"
 
         case "$(uname -s)" in
           Linux) os="linux" ;;
@@ -37,15 +38,17 @@ runs:
         esac
 
         artifact="moonbit-${os}-${arch}.tar.gz"
-        base_url="https://cli.moonbitlang.com/binaries/${version}"
-        archive_url="${base_url}/${artifact}"
+        archive_url="https://cli.moonbitlang.com/binaries/${encoded_version}/${artifact}"
         checksum_url="${archive_url}.sha256"
+        core_archive="core-${encoded_version}.tar.gz"
+        core_url="https://cli.moonbitlang.com/cores/${core_archive}"
 
         tmpdir="$(mktemp -d)"
         trap 'rm -rf "$tmpdir"' EXIT
 
         curl -fsSLo "$tmpdir/$artifact" "$archive_url"
         curl -fsSLo "$tmpdir/${artifact}.sha256" "$checksum_url"
+        curl -fsSLo "$tmpdir/$core_archive" "$core_url"
 
         expected_sha="$(awk '{ print $1 }' "$tmpdir/${artifact}.sha256")"
         actual_sha="$(shasum -a 256 "$tmpdir/$artifact" | awk '{ print $1 }')"
@@ -56,6 +59,8 @@ runs:
 
         extract_dir="$tmpdir/extract"
         install_root="$HOME/.moon"
+        bin_dir="$install_root/bin"
+        lib_dir="$install_root/lib"
         mkdir -p "$extract_dir"
         tar -xzf "$tmpdir/$artifact" -C "$extract_dir"
 
@@ -72,6 +77,17 @@ runs:
         rm -rf "$install_root"
         mkdir -p "$install_root"
         cp -R "$install_src"/. "$install_root"/
+        chmod +x "$bin_dir"/*
+        if [ -e "$bin_dir/internal/tcc" ]; then
+          chmod +x "$bin_dir/internal/tcc"
+        fi
+
+        rm -rf "$lib_dir/core"
+        mkdir -p "$lib_dir"
+        tar -xzf "$tmpdir/$core_archive" -C "$lib_dir"
+
+        PATH="$bin_dir:$PATH" "$bin_dir/moon" -C "$lib_dir/core" bundle --warn-list -a --all
+        PATH="$bin_dir:$PATH" "$bin_dir/moon" -C "$lib_dir/core" bundle --warn-list -a --target wasm-gc --quiet
 
         "$install_root/bin/moon" version
         echo "$install_root/bin" >> "$GITHUB_PATH"

--- a/.github/actions/setup-moonbit/action.yml
+++ b/.github/actions/setup-moonbit/action.yml
@@ -21,7 +21,7 @@ runs:
           mktemp -d -t papion-moonbit
         }
 
-        validate_tar_paths() {
+        validate_tar_archive() {
           local archive="$1"
           local entry
           while IFS= read -r entry; do
@@ -32,6 +32,20 @@ runs:
                 ;;
             esac
           done < <(tar -tzf "$archive")
+
+          local metadata
+          local type
+          while IFS= read -r metadata; do
+            type="${metadata:0:1}"
+            case "$type" in
+              d|-)
+                ;;
+              *)
+                echo "::error::Unsupported archive entry type '$type' in $archive: $metadata"
+                return 1
+                ;;
+            esac
+          done < <(tar -tvzf "$archive" | awk '{ print $1 }')
         }
 
         reject_symlinks() {
@@ -89,7 +103,21 @@ runs:
         curl -fsSL --retry 3 -o "$tmpdir/${artifact}.sha256" "$checksum_url"
         curl -fsSL --retry 3 -o "$tmpdir/$core_archive" "$core_url"
 
-        expected_sha="$(awk '{ print $1 }' "$tmpdir/${artifact}.sha256")"
+        checksum_file="$tmpdir/${artifact}.sha256"
+        expected_sha="$(awk 'NR == 1 { print $1 }' "$checksum_file")"
+        checksum_target="$(awk 'NR == 1 { print $2 }' "$checksum_file")"
+        checksum_target="${checksum_target#\*}"
+        if [[ ! "$expected_sha" =~ ^[0-9a-fA-F]{64}$ ]]; then
+          echo "::error::Invalid sha256 content in $checksum_url"
+          echo "::error::expected a 64-character hex digest, got: ${expected_sha:-<empty>}"
+          exit 1
+        fi
+        if [ -n "$checksum_target" ] && [ "$checksum_target" != "$artifact" ]; then
+          echo "::error::Checksum file target mismatch in $checksum_url"
+          echo "::error::expected filename: $artifact"
+          echo "::error::checksum filename: $checksum_target"
+          exit 1
+        fi
         actual_sha="$(shasum -a 256 "$tmpdir/$artifact" | awk '{ print $1 }')"
         if [ "$actual_sha" != "$expected_sha" ]; then
           echo "::error::MoonBit archive checksum verification failed for $artifact from $archive_url"
@@ -105,7 +133,7 @@ runs:
         lib_dir="$install_root/lib"
         mkdir -p "$extract_dir"
         mkdir -p "$core_extract_dir"
-        validate_tar_paths "$tmpdir/$artifact"
+        validate_tar_archive "$tmpdir/$artifact"
         tar -xzf "$tmpdir/$artifact" -C "$extract_dir"
 
         install_src="$extract_dir"
@@ -132,7 +160,7 @@ runs:
 
         rm -rf "$lib_dir/core"
         mkdir -p "$lib_dir"
-        validate_tar_paths "$tmpdir/$core_archive"
+        validate_tar_archive "$tmpdir/$core_archive"
         tar -xzf "$tmpdir/$core_archive" -C "$core_extract_dir"
         if [ ! -d "$core_extract_dir/core" ] || [ ! -f "$core_extract_dir/core/moon.mod.json" ]; then
           echo "::error::Invalid MoonBit core archive layout in $core_archive from $core_url"

--- a/.github/actions/setup-moonbit/action.yml
+++ b/.github/actions/setup-moonbit/action.yml
@@ -65,11 +65,11 @@ runs:
         tar -xzf "$tmpdir/$artifact" -C "$extract_dir"
 
         install_src="$extract_dir"
-        if [ ! -x "$install_src/bin/moon" ]; then
+        if [ ! -e "$install_src/bin/moon" ]; then
           install_src="$(find "$extract_dir" -mindepth 1 -maxdepth 2 -type d -path '*/bin' | sed 's#/bin$##' | head -n 1)"
         fi
 
-        if [ -z "$install_src" ] || [ ! -x "$install_src/bin/moon" ]; then
+        if [ -z "$install_src" ] || [ ! -e "$install_src/bin/moon" ]; then
           echo "::error::Could not locate extracted MoonBit toolchain in $artifact"
           exit 1
         fi

--- a/.github/actions/setup-moonbit/action.yml
+++ b/.github/actions/setup-moonbit/action.yml
@@ -12,6 +12,28 @@ runs:
       run: |
         set -euo pipefail
 
+        make_temp_dir() {
+          local dir
+          if dir="$(mktemp -d 2>/dev/null)"; then
+            printf '%s\n' "$dir"
+            return 0
+          fi
+          mktemp -d -t papion-moonbit
+        }
+
+        validate_tar_paths() {
+          local archive="$1"
+          local entry
+          while IFS= read -r entry; do
+            case "$entry" in
+              /*|../*|*/../*|..|*/..)
+                echo "::error::Unsafe archive entry '$entry' in $archive"
+                return 1
+                ;;
+            esac
+          done < <(tar -tzf "$archive")
+        }
+
         version="${{ inputs.version }}"
         if [ -z "$version" ]; then
           echo "::error::setup-moonbit requires an explicit MoonBit version"
@@ -49,12 +71,12 @@ runs:
         core_archive="core-${version}.tar.gz"
         core_url="https://cli.moonbitlang.com/cores/core-${encoded_version}.tar.gz"
 
-        tmpdir="$(mktemp -d)"
+        tmpdir="$(make_temp_dir)"
         trap 'rm -rf "$tmpdir"' EXIT
 
-        curl -fsSLo "$tmpdir/$artifact" "$archive_url"
-        curl -fsSLo "$tmpdir/${artifact}.sha256" "$checksum_url"
-        curl -fsSLo "$tmpdir/$core_archive" "$core_url"
+        curl -fsSL --retry 3 -o "$tmpdir/$artifact" "$archive_url"
+        curl -fsSL --retry 3 -o "$tmpdir/${artifact}.sha256" "$checksum_url"
+        curl -fsSL --retry 3 -o "$tmpdir/$core_archive" "$core_url"
 
         expected_sha="$(awk '{ print $1 }' "$tmpdir/${artifact}.sha256")"
         actual_sha="$(shasum -a 256 "$tmpdir/$artifact" | awk '{ print $1 }')"
@@ -72,6 +94,7 @@ runs:
         lib_dir="$install_root/lib"
         mkdir -p "$extract_dir"
         mkdir -p "$core_extract_dir"
+        validate_tar_paths "$tmpdir/$artifact"
         tar -xzf "$tmpdir/$artifact" -C "$extract_dir"
 
         install_src="$extract_dir"
@@ -97,6 +120,7 @@ runs:
 
         rm -rf "$lib_dir/core"
         mkdir -p "$lib_dir"
+        validate_tar_paths "$tmpdir/$core_archive"
         tar -xzf "$tmpdir/$core_archive" -C "$core_extract_dir"
         if [ ! -d "$core_extract_dir/core" ] || [ ! -f "$core_extract_dir/core/moon.mod.json" ]; then
           echo "::error::Invalid MoonBit core archive layout in $core_archive from $core_url"

--- a/.github/actions/setup-moonbit/action.yml
+++ b/.github/actions/setup-moonbit/action.yml
@@ -53,7 +53,9 @@ runs:
         expected_sha="$(awk '{ print $1 }' "$tmpdir/${artifact}.sha256")"
         actual_sha="$(shasum -a 256 "$tmpdir/$artifact" | awk '{ print $1 }')"
         if [ "$actual_sha" != "$expected_sha" ]; then
-          echo "::error::MoonBit archive checksum verification failed for $artifact"
+          echo "::error::MoonBit archive checksum verification failed for $artifact from $archive_url"
+          echo "::error::expected sha256: $expected_sha"
+          echo "::error::actual sha256:   $actual_sha"
           exit 1
         fi
 
@@ -85,6 +87,10 @@ runs:
         rm -rf "$lib_dir/core"
         mkdir -p "$lib_dir"
         tar -xzf "$tmpdir/$core_archive" -C "$lib_dir"
+        if [ ! -d "$lib_dir/core" ] || [ ! -f "$lib_dir/core/moon.mod.json" ]; then
+          echo "::error::Invalid MoonBit core archive layout in $core_archive from $core_url"
+          exit 1
+        fi
 
         PATH="$bin_dir:$PATH" "$bin_dir/moon" -C "$lib_dir/core" bundle --warn-list -a --all
         PATH="$bin_dir:$PATH" "$bin_dir/moon" -C "$lib_dir/core" bundle --warn-list -a --target wasm-gc --quiet

--- a/.github/actions/setup-moonbit/action.yml
+++ b/.github/actions/setup-moonbit/action.yml
@@ -23,6 +23,19 @@ runs:
 
         validate_tar_archive() {
           local archive="$1"
+          local validate_dir
+          validate_dir="$(make_temp_dir)"
+          if ! tar -tzf "$archive" > "$validate_dir/paths"; then
+            echo "::error::Failed to list archive paths in $archive"
+            rm -rf "$validate_dir"
+            return 1
+          fi
+          if ! tar -tvzf "$archive" > "$validate_dir/metadata"; then
+            echo "::error::Failed to inspect archive metadata in $archive"
+            rm -rf "$validate_dir"
+            return 1
+          fi
+
           local entry
           local normalized_entry
           while IFS= read -r entry; do
@@ -33,24 +46,28 @@ runs:
             case "$normalized_entry" in
               /*|../*|*/../*|..|*/..)
                 echo "::error::Unsafe archive entry '$entry' in $archive"
+                rm -rf "$validate_dir"
                 return 1
                 ;;
             esac
-          done < <(tar -tzf "$archive")
+          done < "$validate_dir/paths"
 
           local metadata
           local type
           while IFS= read -r metadata; do
             type="${metadata:0:1}"
             case "$type" in
-              d|-)
+              d|-|x|g|L|K)
                 ;;
               *)
                 echo "::error::Unsupported archive entry type '$type' in $archive: $metadata"
+                rm -rf "$validate_dir"
                 return 1
                 ;;
             esac
-          done < <(tar -tvzf "$archive")
+          done < "$validate_dir/metadata"
+
+          rm -rf "$validate_dir"
         }
 
         reject_symlinks() {

--- a/.github/actions/setup-moonbit/action.yml
+++ b/.github/actions/setup-moonbit/action.yml
@@ -24,8 +24,13 @@ runs:
         validate_tar_archive() {
           local archive="$1"
           local entry
+          local normalized_entry
           while IFS= read -r entry; do
-            case "$entry" in
+            normalized_entry="$entry"
+            while [[ "$normalized_entry" == ./* ]]; do
+              normalized_entry="${normalized_entry#./}"
+            done
+            case "$normalized_entry" in
               /*|../*|*/../*|..|*/..)
                 echo "::error::Unsafe archive entry '$entry' in $archive"
                 return 1
@@ -45,7 +50,7 @@ runs:
                 return 1
                 ;;
             esac
-          done < <(tar -tvzf "$archive" | awk '{ print $1 }')
+          done < <(tar -tvzf "$archive")
         }
 
         reject_symlinks() {

--- a/.github/actions/setup-moonbit/action.yml
+++ b/.github/actions/setup-moonbit/action.yml
@@ -17,6 +17,12 @@ runs:
           echo "::error::setup-moonbit requires an explicit MoonBit version"
           exit 1
         fi
+        case "$version" in
+          *[!A-Za-z0-9._+-]*|*..*)
+            echo "::error::Invalid MoonBit version: $version"
+            exit 1
+            ;;
+        esac
         encoded_version="${version//+/%2B}"
 
         case "$(uname -s)" in
@@ -40,7 +46,7 @@ runs:
         artifact="moonbit-${os}-${arch}.tar.gz"
         archive_url="https://cli.moonbitlang.com/binaries/${encoded_version}/${artifact}"
         checksum_url="${archive_url}.sha256"
-        core_archive="core-${encoded_version}.tar.gz"
+        core_archive="core-${version}.tar.gz"
         core_url="https://cli.moonbitlang.com/cores/${core_archive}"
 
         tmpdir="$(mktemp -d)"

--- a/.github/actions/setup-moonbit/action.yml
+++ b/.github/actions/setup-moonbit/action.yml
@@ -68,7 +68,10 @@ runs:
 
         install_src="$extract_dir"
         if [ ! -e "$install_src/bin/moon" ]; then
-          install_src="$(find "$extract_dir" -mindepth 1 -maxdepth 2 -type d -path '*/bin' | sed 's#/bin$##' | head -n 1)"
+          bin_dir_match="$(find "$extract_dir" -mindepth 1 -maxdepth 2 -type d -path '*/bin' -print -quit)"
+          if [ -n "$bin_dir_match" ]; then
+            install_src="${bin_dir_match%/bin}"
+          fi
         fi
 
         if [ -z "$install_src" ] || [ ! -e "$install_src/bin/moon" ]; then

--- a/.github/actions/setup-moonbit/action.yml
+++ b/.github/actions/setup-moonbit/action.yml
@@ -47,7 +47,7 @@ runs:
         archive_url="https://cli.moonbitlang.com/binaries/${encoded_version}/${artifact}"
         checksum_url="${archive_url}.sha256"
         core_archive="core-${version}.tar.gz"
-        core_url="https://cli.moonbitlang.com/cores/${core_archive}"
+        core_url="https://cli.moonbitlang.com/cores/core-${encoded_version}.tar.gz"
 
         tmpdir="$(mktemp -d)"
         trap 'rm -rf "$tmpdir"' EXIT

--- a/.github/actions/setup-moonbit/action.yml
+++ b/.github/actions/setup-moonbit/action.yml
@@ -34,6 +34,17 @@ runs:
           done < <(tar -tzf "$archive")
         }
 
+        reject_symlinks() {
+          local root="$1"
+          local label="$2"
+          local link
+          link="$(find "$root" -type l -print -quit)"
+          if [ -n "$link" ]; then
+            echo "::error::Unexpected symlink in $label: $link"
+            return 1
+          fi
+        }
+
         version="${{ inputs.version }}"
         if [ -z "$version" ]; then
           echo "::error::setup-moonbit requires an explicit MoonBit version"
@@ -109,11 +120,12 @@ runs:
           echo "::error::Could not locate extracted MoonBit toolchain in $artifact"
           exit 1
         fi
+        reject_symlinks "$install_src" "MoonBit toolchain"
 
         rm -rf "$install_root"
         mkdir -p "$install_root"
         cp -R "$install_src"/. "$install_root"/
-        chmod +x "$bin_dir"/*
+        find "$bin_dir" -maxdepth 1 -type f -exec chmod +x {} +
         if [ -e "$bin_dir/internal/tcc" ]; then
           chmod +x "$bin_dir/internal/tcc"
         fi
@@ -126,6 +138,7 @@ runs:
           echo "::error::Invalid MoonBit core archive layout in $core_archive from $core_url"
           exit 1
         fi
+        reject_symlinks "$core_extract_dir/core" "MoonBit core archive"
         cp -R "$core_extract_dir/core" "$lib_dir/core"
 
         PATH="$bin_dir:$PATH" "$bin_dir/moon" -C "$lib_dir/core" bundle --warn-list -a --all

--- a/.github/actions/setup-moonbit/action.yml
+++ b/.github/actions/setup-moonbit/action.yml
@@ -66,10 +66,12 @@ runs:
         fi
 
         extract_dir="$tmpdir/extract"
+        core_extract_dir="$tmpdir/core-extract"
         install_root="$HOME/.moon"
         bin_dir="$install_root/bin"
         lib_dir="$install_root/lib"
         mkdir -p "$extract_dir"
+        mkdir -p "$core_extract_dir"
         tar -xzf "$tmpdir/$artifact" -C "$extract_dir"
 
         install_src="$extract_dir"
@@ -95,11 +97,12 @@ runs:
 
         rm -rf "$lib_dir/core"
         mkdir -p "$lib_dir"
-        tar -xzf "$tmpdir/$core_archive" -C "$lib_dir"
-        if [ ! -d "$lib_dir/core" ] || [ ! -f "$lib_dir/core/moon.mod.json" ]; then
+        tar -xzf "$tmpdir/$core_archive" -C "$core_extract_dir"
+        if [ ! -d "$core_extract_dir/core" ] || [ ! -f "$core_extract_dir/core/moon.mod.json" ]; then
           echo "::error::Invalid MoonBit core archive layout in $core_archive from $core_url"
           exit 1
         fi
+        cp -R "$core_extract_dir/core" "$lib_dir/core"
 
         PATH="$bin_dir:$PATH" "$bin_dir/moon" -C "$lib_dir/core" bundle --warn-list -a --all
         PATH="$bin_dir:$PATH" "$bin_dir/moon" -C "$lib_dir/core" bundle --warn-list -a --target wasm-gc --quiet

--- a/.github/actions/setup-moonbit/action.yml
+++ b/.github/actions/setup-moonbit/action.yml
@@ -3,17 +3,75 @@ description: Install a MoonBit toolchain for CI
 inputs:
   version:
     description: MoonBit release version to install
-    required: false
-    default: ""
+    required: true
 runs:
   using: composite
   steps:
     - name: Install MoonBit CLI
       shell: bash
       run: |
-        if [ -n "${{ inputs.version }}" ]; then
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- "${{ inputs.version }}"
-        else
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
+        set -euo pipefail
+
+        version="${{ inputs.version }}"
+        if [ -z "$version" ]; then
+          echo "::error::setup-moonbit requires an explicit MoonBit version"
+          exit 1
         fi
-        echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
+
+        case "$(uname -s)" in
+          Linux) os="linux" ;;
+          Darwin) os="darwin" ;;
+          *)
+            echo "::error::Unsupported OS: $(uname -s)"
+            exit 1
+            ;;
+        esac
+
+        case "$(uname -m)" in
+          x86_64|amd64) arch="x86_64" ;;
+          arm64|aarch64) arch="aarch64" ;;
+          *)
+            echo "::error::Unsupported architecture: $(uname -m)"
+            exit 1
+            ;;
+        esac
+
+        artifact="moonbit-${os}-${arch}.tar.gz"
+        base_url="https://cli.moonbitlang.com/binaries/${version}"
+        archive_url="${base_url}/${artifact}"
+        checksum_url="${archive_url}.sha256"
+
+        tmpdir="$(mktemp -d)"
+        trap 'rm -rf "$tmpdir"' EXIT
+
+        curl -fsSLo "$tmpdir/$artifact" "$archive_url"
+        curl -fsSLo "$tmpdir/${artifact}.sha256" "$checksum_url"
+
+        expected_sha="$(awk '{ print $1 }' "$tmpdir/${artifact}.sha256")"
+        actual_sha="$(shasum -a 256 "$tmpdir/$artifact" | awk '{ print $1 }')"
+        if [ "$actual_sha" != "$expected_sha" ]; then
+          echo "::error::MoonBit archive checksum verification failed for $artifact"
+          exit 1
+        fi
+
+        extract_dir="$tmpdir/extract"
+        install_root="$HOME/.moon"
+        mkdir -p "$extract_dir"
+        tar -xzf "$tmpdir/$artifact" -C "$extract_dir"
+
+        install_src="$extract_dir"
+        if [ ! -x "$install_src/bin/moon" ]; then
+          install_src="$(find "$extract_dir" -mindepth 1 -maxdepth 2 -type d -path '*/bin' | sed 's#/bin$##' | head -n 1)"
+        fi
+
+        if [ -z "$install_src" ] || [ ! -x "$install_src/bin/moon" ]; then
+          echo "::error::Could not locate extracted MoonBit toolchain in $artifact"
+          exit 1
+        fi
+
+        rm -rf "$install_root"
+        mkdir -p "$install_root"
+        cp -R "$install_src"/. "$install_root"/
+
+        "$install_root/bin/moon" version
+        echo "$install_root/bin" >> "$GITHUB_PATH"


### PR DESCRIPTION
## Summary
- replace the runtime `curl | bash` MoonBit installer with direct downloads from versioned MoonBit archives
- verify the downloaded MoonBit toolchain archive against the published `.sha256` before installing into `$HOME/.moon`
- pin the matching MoonBit core archive to an explicit versioned URL, extract it into a temp directory first, validate the expected `core/moon.mod.json` layout, and then copy only that tree into `$HOME/.moon/lib/core`
- fail fast for missing versions, unsupported platforms, checksum mismatches, or invalid extracted layouts

Closes #54.

## Testing
- `git diff --check`
- networked install flow not run locally because the sandbox restricts outbound downloads

## Note
- MoonBit currently publishes a `.sha256` for the versioned toolchain tarball, but not for the matching `core-<version>.tar.gz` artifact. The action therefore verifies the toolchain archive digest, while the core archive is pinned to a versioned URL and validated by extracted layout rather than checksum.
