### PR TITLE
test(native): cover reusable workflow refs in native integration scenarios

### DIFF
--- a/core/native/native_wbtest.mbt
+++ b/core/native/native_wbtest.mbt
@@ -759,7 +759,7 @@ test "integration: local composite -> local composite -> remote action (zero fin
 }
 
 ///|
-test "integration: local workflow with reusable workflow job ref (zero findings)" {
+test "integration: reusable workflow job ref is evaluated (unpinned ref fails sha_pinning policy)" {
   guard @env.current_dir() is Some(cwd) else {
     fail("expected current working directory")
   }
@@ -770,7 +770,7 @@ test "integration: local workflow with reusable workflow job ref (zero findings)
     let repo_root = find_git_root(scenario_dir)
     let result = @cli.run_with_host(
       ["run", scenario, "--fail-on", "warn"],
-      fn(_) { Ok(@papion.Policy::default()) },
+      fn(_) { Ok({ ..@papion.Policy::default(), sha_pinning: true }) },
       stub_fetch_action_yml,
       read_local_target,
       fetch_local=fl,
@@ -778,7 +778,8 @@ test "integration: local workflow with reusable workflow job ref (zero findings)
     )
     match result {
       Err(e) => fail("unexpected error: \{e}")
-      Ok(outcome) => assert_eq(outcome.exit_code, 0)
+      // exit_code 1 only if the @main reusable job ref was evaluated; the step ref alone would be 0.
+      Ok(outcome) => assert_eq(outcome.exit_code, 1)
     }
   })
 }

--- a/core/native/native_wbtest.mbt
+++ b/core/native/native_wbtest.mbt
@@ -757,3 +757,28 @@ test "integration: local composite -> local composite -> remote action (zero fin
     }
   })
 }
+
+///|
+test "integration: local workflow with reusable workflow job ref (zero findings)" {
+  guard @env.current_dir() is Some(cwd) else {
+    fail("expected current working directory")
+  }
+  let scenario_dir = "\{cwd}/native/testdata/scenarios/wf-with-reusable"
+  let scenario = "\{scenario_dir}/.github/workflows/ci.yml"
+  with_scenario_git_root(scenario_dir, () => {
+    let fl = build_fetch_local(scenario)
+    let repo_root = find_git_root(scenario_dir)
+    let result = @cli.run_with_host(
+      ["run", scenario, "--fail-on", "warn"],
+      fn(_) { Ok(@papion.Policy::default()) },
+      stub_fetch_action_yml,
+      read_local_target,
+      fetch_local=fl,
+      repo_root?,
+    )
+    match result {
+      Err(e) => fail("unexpected error: \{e}")
+      Ok(outcome) => assert_eq(outcome.exit_code, 0)
+    }
+  })
+}

--- a/core/native/testdata/scenarios/wf-with-reusable/.github/workflows/ci.yml
+++ b/core/native/testdata/scenarios/wf-with-reusable/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on: [push]
 jobs:
   reusable:
-    uses: org/reusable/.github/workflows/build.yml@11bd71901bbe5b1630ceea73d27597364c9af683
+    uses: org/reusable/.github/workflows/build.yml@main
   build:
     runs-on: ubuntu-latest
     steps:

--- a/core/native/testdata/scenarios/wf-with-reusable/.github/workflows/ci.yml
+++ b/core/native/testdata/scenarios/wf-with-reusable/.github/workflows/ci.yml
@@ -1,0 +1,9 @@
+name: CI
+on: [push]
+jobs:
+  reusable:
+    uses: org/reusable/.github/workflows/build.yml@11bd71901bbe5b1630ceea73d27597364c9af683
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
## Summary

- `jobs.<id>.uses` (reusable workflow) refs were already fully implemented in PR #68 (`ParsedRef::ReusableWorkflow`, parser extraction, engine evaluation without recursion, unit + engine tests).
- What was missing: an end-to-end scenario exercising the native host boundary.
- Adds `core/native/testdata/scenarios/wf-with-reusable/` with a workflow that has both a job-level `uses` (reusable workflow, SHA-pinned) and a step-level `uses` (SHA-pinned). Default policy → zero findings.
- Appends one integration test to `native_wbtest.mbt` using the existing `with_scenario_git_root` / `stub_fetch_action_yml` harness.

Closes #69.

## Test plan

- [x] `moon test --target native` — 254 passed, 0 failed
- [x] `moon fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)