### PR TITLE
feat(core)!: make SHA pinning mandatory; remove sha_pinning policy field

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Papion looks for configuration in the following order (first found wins):
 2. `.github/papion.toml`
 3. `papion.toml` (repo root)
 
+SHA pinning is always enforced — actions must resolve to a SHA or an immutable release.
+
 ```toml
 [policy]
-sha_pinning = true  # default: true
-
 allowed = [
   "actions/*",
   "github/*",

--- a/core/README.mbt.md
+++ b/core/README.mbt.md
@@ -101,11 +101,12 @@ Scanning policy configuration.
 
 ```
 Policy {
-  sha_pinning : Bool              // default: true
   allowed : Array[String]         // glob patterns, e.g. ["actions/*"]
   disallowed : Array[String]      // glob patterns
 }
 ```
+
+SHA pinning is always enforced and is not configurable.
 
 ### ScanTarget
 

--- a/core/config/config.mbt
+++ b/core/config/config.mbt
@@ -2,7 +2,7 @@
 /// Parse a policy configuration JSON string into a Policy.
 ///
 /// The host converts TOML to JSON before passing to this function.
-/// Missing fields use defaults: sha_pinning=true, allowed=[], disallowed=[].
+/// Missing fields use defaults: allowed=[], disallowed=[].
 /// Returns Err if any pattern exceeds 256 characters.
 /// Patterns are normalized to lowercase before returning.
 pub fn parse_policy(json_str : String) -> Result[@papion.Policy, String] {
@@ -15,12 +15,6 @@ pub fn parse_policy(json_str : String) -> Result[@papion.Policy, String] {
       None => obj
       Some(Object(inner)) => inner
       Some(_) => return Err("invalid 'policy' field: expected object")
-    }
-    let sha_pinning = match obj.get("sha_pinning") {
-      Some(True) => true
-      Some(False) => false
-      None => true
-      Some(_) => return Err("invalid 'sha_pinning' field: expected boolean")
     }
     let allowed = match obj.get("allowed") {
       None => []
@@ -50,7 +44,7 @@ pub fn parse_policy(json_str : String) -> Result[@papion.Policy, String] {
       }
       Some(_) => return Err("invalid 'disallowed' field: expected array")
     }
-    @papion.Policy::{ sha_pinning, allowed, disallowed }.normalized()
+    @papion.Policy::{ allowed, disallowed }.normalized()
   } catch {
     e => Err(e.to_string())
   }

--- a/core/config/config_test.mbt
+++ b/core/config/config_test.mbt
@@ -1,22 +1,18 @@
 ///|
 test "parse_policy full config" {
   let json_str =
-    #|{"sha_pinning":false,"allowed":["actions/*","github/*"],"disallowed":["bad-org/unsafe"]}
+    #|{"allowed":["actions/*","github/*"],"disallowed":["bad-org/unsafe"]}
   let result = parse_policy(json_str)
   assert_eq(
     result,
-    Ok({
-      sha_pinning: false,
-      allowed: ["actions/*", "github/*"],
-      disallowed: ["bad-org/unsafe"],
-    }),
+    Ok({ allowed: ["actions/*", "github/*"], disallowed: ["bad-org/unsafe"] }),
   )
 }
 
 ///|
 test "parse_policy defaults on empty object" {
   let result = parse_policy("{}")
-  assert_eq(result, Ok({ sha_pinning: true, allowed: [], disallowed: [] }))
+  assert_eq(result, Ok({ allowed: [], disallowed: [] }))
 }
 
 ///|
@@ -37,13 +33,10 @@ test "parse_policy rejects non-object top-level JSON" {
 }
 
 ///|
-test "parse_policy rejects non-bool sha_pinning" {
+test "parse_policy ignores legacy sha_pinning field" {
   let json_str =
-    #|{"sha_pinning":"false"}
-  match parse_policy(json_str) {
-    Err(_) => ()
-    Ok(_) => fail("expected Err for non-bool sha_pinning")
-  }
+    #|{"sha_pinning":false,"allowed":[]}
+  assert_eq(parse_policy(json_str), Ok({ allowed: [], disallowed: [] }))
 }
 
 ///|
@@ -89,15 +82,11 @@ test "parse_policy rejects non-string entry in disallowed" {
 ///|
 test "parse_policy nested policy key full config" {
   let json_str =
-    #|{"policy":{"sha_pinning":false,"allowed":["actions/*"],"disallowed":["bad-org/unsafe"]}}
+    #|{"policy":{"allowed":["actions/*"],"disallowed":["bad-org/unsafe"]}}
   let result = parse_policy(json_str)
   assert_eq(
     result,
-    Ok({
-      sha_pinning: false,
-      allowed: ["actions/*"],
-      disallowed: ["bad-org/unsafe"],
-    }),
+    Ok({ allowed: ["actions/*"], disallowed: ["bad-org/unsafe"] }),
   )
 }
 
@@ -118,11 +107,7 @@ test "parse_policy normalizes patterns to lowercase" {
   let result = parse_policy(json_str)
   assert_eq(
     result,
-    Ok({
-      sha_pinning: true,
-      allowed: ["actions/*", "github/*"],
-      disallowed: ["bad-org/unsafe"],
-    }),
+    Ok({ allowed: ["actions/*", "github/*"], disallowed: ["bad-org/unsafe"] }),
   )
 }
 
@@ -151,16 +136,12 @@ test "parse_policy nested policy key empty object uses defaults" {
   let json_str =
     #|{"policy":{}}
   let result = parse_policy(json_str)
-  assert_eq(result, Ok({ sha_pinning: true, allowed: [], disallowed: [] }))
+  assert_eq(result, Ok({ allowed: [], disallowed: [] }))
 }
 
 ///|
 test "matches_allowed empty list passes all" {
-  let policy : @papion.Policy = {
-    sha_pinning: true,
-    allowed: [],
-    disallowed: [],
-  }
+  let policy : @papion.Policy = { allowed: [], disallowed: [] }
   let action_ref : @papion.ActionRef = {
     owner: "actions",
     repo: "checkout",
@@ -172,11 +153,7 @@ test "matches_allowed empty list passes all" {
 
 ///|
 test "matches_allowed with matching pattern" {
-  let policy : @papion.Policy = {
-    sha_pinning: true,
-    allowed: ["actions/*"],
-    disallowed: [],
-  }
+  let policy : @papion.Policy = { allowed: ["actions/*"], disallowed: [] }
   let action_ref : @papion.ActionRef = {
     owner: "actions",
     repo: "checkout",
@@ -188,11 +165,7 @@ test "matches_allowed with matching pattern" {
 
 ///|
 test "matches_allowed case-insensitive owner in target" {
-  let policy : @papion.Policy = {
-    sha_pinning: true,
-    allowed: ["actions/*"],
-    disallowed: [],
-  }
+  let policy : @papion.Policy = { allowed: ["actions/*"], disallowed: [] }
   let action_ref : @papion.ActionRef = {
     owner: "Actions",
     repo: "Checkout",
@@ -204,11 +177,7 @@ test "matches_allowed case-insensitive owner in target" {
 
 ///|
 test "matches_allowed no match returns false" {
-  let policy : @papion.Policy = {
-    sha_pinning: true,
-    allowed: ["github/*"],
-    disallowed: [],
-  }
+  let policy : @papion.Policy = { allowed: ["github/*"], disallowed: [] }
   let action_ref : @papion.ActionRef = {
     owner: "actions",
     repo: "checkout",
@@ -220,11 +189,7 @@ test "matches_allowed no match returns false" {
 
 ///|
 test "matches_disallowed with matching pattern" {
-  let policy : @papion.Policy = {
-    sha_pinning: true,
-    allowed: [],
-    disallowed: ["bad-org/*"],
-  }
+  let policy : @papion.Policy = { allowed: [], disallowed: ["bad-org/*"] }
   let action_ref : @papion.ActionRef = {
     owner: "bad-org",
     repo: "evil-action",
@@ -236,11 +201,7 @@ test "matches_disallowed with matching pattern" {
 
 ///|
 test "matches_disallowed case-insensitive owner in target" {
-  let policy : @papion.Policy = {
-    sha_pinning: true,
-    allowed: [],
-    disallowed: ["bad-org/*"],
-  }
+  let policy : @papion.Policy = { allowed: [], disallowed: ["bad-org/*"] }
   let action_ref : @papion.ActionRef = {
     owner: "Bad-Org",
     repo: "Evil-Action",
@@ -252,11 +213,7 @@ test "matches_disallowed case-insensitive owner in target" {
 
 ///|
 test "matches_disallowed no match returns false" {
-  let policy : @papion.Policy = {
-    sha_pinning: true,
-    allowed: [],
-    disallowed: ["other-org/*"],
-  }
+  let policy : @papion.Policy = { allowed: [], disallowed: ["other-org/*"] }
   let action_ref : @papion.ActionRef = {
     owner: "actions",
     repo: "checkout",

--- a/core/engine/engine.mbt
+++ b/core/engine/engine.mbt
@@ -263,11 +263,7 @@ fn scan_impl(
       match parsed_ref {
         @papion.ReusableWorkflow(ref_) => {
           // Evaluate pin policy for the call site but do not fetch or recurse.
-          let ref_kind = if policy.sha_pinning {
-            resolve_ref_kind(ref_.owner, ref_.repo, ref_.git_ref)
-          } else {
-            Branch
-          }
+          let ref_kind = resolve_ref_kind(ref_.owner, ref_.repo, ref_.git_ref)
           let ref_findings = @rules.evaluate(ref_, ref_kind, policy)
           for finding in ref_findings {
             let with_context = match node.via {
@@ -278,11 +274,7 @@ fn scan_impl(
           }
         }
         @papion.GitHub(ref_) => {
-          let ref_kind = if policy.sha_pinning {
-            resolve_ref_kind(ref_.owner, ref_.repo, ref_.git_ref)
-          } else {
-            Branch
-          }
+          let ref_kind = resolve_ref_kind(ref_.owner, ref_.repo, ref_.git_ref)
           let ref_findings = @rules.evaluate(ref_, ref_kind, policy)
           for finding in ref_findings {
             let with_context = match node.via {

--- a/core/engine/engine_test.mbt
+++ b/core/engine/engine_test.mbt
@@ -81,7 +81,6 @@ test "scan disallowed action produces failure" {
     #|  steps:
     #|    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
   let policy : @papion.Policy = {
-    sha_pinning: true,
     allowed: [],
     disallowed: ["actions/checkout"],
   }
@@ -105,11 +104,7 @@ test "scan allowed list restricts to listed actions" {
     #|  steps:
     #|    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
     #|    - uses: third-party/action@11bd71901bbe5b1630ceea73d27597364c9af683
-  let policy : @papion.Policy = {
-    sha_pinning: true,
-    allowed: ["actions/*"],
-    disallowed: [],
-  }
+  let policy : @papion.Policy = { allowed: ["actions/*"], disallowed: [] }
   let result = scan(target, yaml_str, policy, unreachable_fetch)
   match result {
     Err(e) => fail("unexpected error: \{e}")
@@ -255,11 +250,7 @@ test "scan normalizes policy patterns before evaluation" {
     #|  using: composite
     #|  steps:
     #|    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-  let policy : @papion.Policy = {
-    sha_pinning: true,
-    allowed: ["Actions/*"],
-    disallowed: [],
-  }
+  let policy : @papion.Policy = { allowed: ["Actions/*"], disallowed: [] }
   let result = scan(target, yaml_str, policy, unreachable_fetch)
   match result {
     Err(e) => fail("unexpected error: \{e}")
@@ -275,11 +266,7 @@ test "scan rejects overlong policy patterns" {
     #|name: My Action
     #|runs:
     #|  using: node20
-  let policy : @papion.Policy = {
-    sha_pinning: true,
-    allowed: [long_pattern],
-    disallowed: [],
-  }
+  let policy : @papion.Policy = { allowed: [long_pattern], disallowed: [] }
   match scan(target, yaml_str, policy, unreachable_fetch) {
     Err(_) => ()
     Ok(_) => fail("expected Err for overlong policy pattern")
@@ -749,51 +736,6 @@ test "scan normalizes root key for mixed-case root cycle" {
       assert_eq(r.findings.length(), 1)
       // But the root action is not re-fetched when casing differs.
       assert_eq(fetch_count, 0)
-    }
-  }
-}
-
-///|
-test "scan skips resolver when sha_pinning disabled" {
-  let target : @papion.ScanTarget = github_target("org", "action-a", "v1")
-  let a_yaml =
-    #|name: Action A
-    #|runs:
-    #|  using: composite
-    #|  steps:
-    #|    - uses: org/action-b@main
-    #|    - uses: org/action-c@main
-  let b_yaml =
-    #|name: Action B
-    #|runs:
-    #|  using: node20
-  let c_yaml =
-    #|name: Action C
-    #|runs:
-    #|  using: node20
-  let fetch = make_fetch_table({
-    "org/action-b@main": b_yaml,
-    "org/action-c@main": c_yaml,
-  })
-  let policy : @papion.Policy = {
-    sha_pinning: false,
-    allowed: [],
-    disallowed: [],
-  }
-  let mut resolve_calls = 0
-  let result = scan(target, a_yaml, policy, fetch, resolve_ref_kind=fn(
-    _owner,
-    _repo,
-    _git_ref,
-  ) {
-    resolve_calls = resolve_calls + 1
-    ImmutableRelease
-  })
-  match result {
-    Err(e) => fail("unexpected error: \{e}")
-    Ok(r) => {
-      assert_eq(resolve_calls, 0)
-      assert_eq(r.findings, [])
     }
   }
 }

--- a/core/native/config.mbt
+++ b/core/native/config.mbt
@@ -30,11 +30,6 @@ fn parse_policy_toml(value : @toml.TomlValue) -> Result[@papion.Policy, String] 
     Some(@toml.TomlTable(inner)) => inner
     Some(_) => return Err("invalid 'policy' field: expected table")
   }
-  let sha_pinning = match obj.get("sha_pinning") {
-    Some(@toml.TomlBoolean(b)) => b
-    None => true
-    Some(_) => return Err("invalid 'sha_pinning' field: expected boolean")
-  }
   let allowed = match parse_pattern_list(obj.get("allowed"), "allowed") {
     Ok(allowed) => allowed
     Err(err) => return Err(err)
@@ -44,7 +39,7 @@ fn parse_policy_toml(value : @toml.TomlValue) -> Result[@papion.Policy, String] 
     Ok(disallowed) => disallowed
     Err(err) => return Err(err)
   }
-  @papion.Policy::{ sha_pinning, allowed, disallowed }.normalized()
+  @papion.Policy::{ allowed, disallowed }.normalized()
 }
 
 ///|

--- a/core/native/native_wbtest.mbt
+++ b/core/native/native_wbtest.mbt
@@ -10,7 +10,6 @@ test "load_config parses TOML fixture into policy" {
     Err(err) => fail(err)
   }
   assert_eq(policy, {
-    sha_pinning: false,
     allowed: ["actions/*", "github/*"],
     disallowed: ["bad-org/unsafe"],
   })
@@ -759,7 +758,7 @@ test "integration: local composite -> local composite -> remote action (zero fin
 }
 
 ///|
-test "integration: reusable workflow job ref is evaluated (unpinned ref fails sha_pinning policy)" {
+test "integration: reusable workflow job ref is evaluated (unpinned ref produces sha-pinning finding)" {
   guard @env.current_dir() is Some(cwd) else {
     fail("expected current working directory")
   }
@@ -770,7 +769,7 @@ test "integration: reusable workflow job ref is evaluated (unpinned ref fails sh
     let repo_root = find_git_root(scenario_dir)
     let result = @cli.run_with_host(
       ["run", scenario, "--fail-on", "warn"],
-      fn(_) { Ok({ ..@papion.Policy::default(), sha_pinning: true }) },
+      fn(_) { Ok(@papion.Policy::default()) },
       stub_fetch_action_yml,
       read_local_target,
       fetch_local=fl,

--- a/core/papion.mbt
+++ b/core/papion.mbt
@@ -235,7 +235,7 @@ pub fn Policy::normalized(self : Policy) -> Result[Policy, String] {
     Ok(patterns) => patterns
     Err(err) => return Err(err)
   }
-  Ok({ ..self, allowed, disallowed })
+  Ok({ allowed, disallowed })
 }
 
 ///|

--- a/core/papion.mbt
+++ b/core/papion.mbt
@@ -210,7 +210,6 @@ pub impl Show for Finding with output(self, logger) {
 
 ///|
 pub(all) struct Policy {
-  sha_pinning : Bool
   allowed : Array[String]
   disallowed : Array[String]
 } derive(Debug, Eq, ToJson, FromJson)
@@ -222,7 +221,7 @@ pub impl Show for Policy with output(self, logger) {
 
 ///|
 pub fn Policy::default() -> Policy {
-  { sha_pinning: true, allowed: [], disallowed: [] }
+  { allowed: [], disallowed: [] }
 }
 
 ///|

--- a/core/papion_test.mbt
+++ b/core/papion_test.mbt
@@ -91,7 +91,6 @@ test "Finding with context" {
 ///|
 test "Policy json roundtrip" {
   let p : @papion.Policy = {
-    sha_pinning: true,
     allowed: ["actions/*", "github/*"],
     disallowed: ["some-org/unsafe-action"],
   }
@@ -103,7 +102,6 @@ test "Policy json roundtrip" {
 ///|
 test "Policy defaults" {
   let p = @papion.Policy::default()
-  assert_eq(p.sha_pinning, true)
   assert_eq(p.allowed, ([] : Array[String]))
   assert_eq(p.disallowed, ([] : Array[String]))
 }
@@ -111,28 +109,19 @@ test "Policy defaults" {
 ///|
 test "Policy normalized lowercases patterns" {
   let policy : @papion.Policy = {
-    sha_pinning: true,
     allowed: ["Actions/*"],
     disallowed: ["Bad-Org/Unsafe"],
   }
   assert_eq(
     policy.normalized(),
-    Ok({
-      sha_pinning: true,
-      allowed: ["actions/*"],
-      disallowed: ["bad-org/unsafe"],
-    }),
+    Ok({ allowed: ["actions/*"], disallowed: ["bad-org/unsafe"] }),
   )
 }
 
 ///|
 test "Policy normalized rejects overlong patterns" {
   let long_pattern = String::make(@papion.max_policy_pattern_len + 1, 'a')
-  let policy : @papion.Policy = {
-    sha_pinning: true,
-    allowed: [long_pattern],
-    disallowed: [],
-  }
+  let policy : @papion.Policy = { allowed: [long_pattern], disallowed: [] }
   match policy.normalized() {
     Err(_) => ()
     Ok(_) => fail("expected Err for overlong policy pattern")

--- a/core/pkg.generated.mbti
+++ b/core/pkg.generated.mbti
@@ -80,7 +80,6 @@ pub(all) enum ParsedRef {
 pub impl Show for ParsedRef
 
 pub(all) struct Policy {
-  sha_pinning : Bool
   allowed : Array[String]
   disallowed : Array[String]
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)

--- a/core/rules/pkg.generated.mbti
+++ b/core/rules/pkg.generated.mbti
@@ -10,7 +10,7 @@ pub fn check_allowed(@papion.ActionRef, @papion.Policy) -> Array[@papion.Finding
 
 pub fn check_disallowed(@papion.ActionRef, @papion.Policy) -> Array[@papion.Finding]
 
-pub fn check_sha_pinning(@papion.ActionRef, @papion.RefKind, @papion.Policy) -> Array[@papion.Finding]
+pub fn check_sha_pinning(@papion.ActionRef, @papion.RefKind) -> Array[@papion.Finding]
 
 pub fn classify_ref(String) -> @papion.RefKind
 

--- a/core/rules/rules.mbt
+++ b/core/rules/rules.mbt
@@ -20,17 +20,12 @@ pub fn classify_ref(git_ref : String) -> @papion.RefKind {
 ///|
 /// Check the SHA-pinning rule against an action reference.
 ///
-/// Produces a Fail finding when sha_pinning is enabled and the ref is neither
-/// a verified commit SHA nor an immutable release. Returns an empty array when
-/// the rule is disabled or the ref is already pinned.
+/// Produces a Fail finding when the ref is neither a verified commit SHA nor
+/// an immutable release. Returns an empty array when the ref is already pinned.
 pub fn check_sha_pinning(
   action_ref : @papion.ActionRef,
   ref_kind : @papion.RefKind,
-  policy : @papion.Policy,
 ) -> Array[@papion.Finding] {
-  if !policy.sha_pinning {
-    return []
-  }
   match ref_kind {
     Sha | ImmutableRelease => return []
     _ => ()
@@ -109,7 +104,7 @@ pub fn evaluate(
   policy : @papion.Policy,
 ) -> Array[@papion.Finding] {
   let findings : Array[@papion.Finding] = []
-  findings.append(check_sha_pinning(action_ref, ref_kind, policy))
+  findings.append(check_sha_pinning(action_ref, ref_kind))
   findings.append(check_allowed(action_ref, policy))
   findings.append(check_disallowed(action_ref, policy))
   findings

--- a/core/rules/rules_test.mbt
+++ b/core/rules/rules_test.mbt
@@ -51,8 +51,7 @@ test "check_sha_pinning SHA ref passes" {
     git_ref: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
     path: None,
   }
-  let policy = @papion.Policy::default()
-  assert_eq(check_sha_pinning(action_ref, Sha, policy), [])
+  assert_eq(check_sha_pinning(action_ref, Sha), [])
 }
 
 ///|
@@ -63,8 +62,7 @@ test "check_sha_pinning non-SHA ref fails" {
     git_ref: "v4",
     path: None,
   }
-  let policy = @papion.Policy::default()
-  let findings = check_sha_pinning(action_ref, Branch, policy)
+  let findings = check_sha_pinning(action_ref, Branch)
   assert_eq(findings.length(), 1)
   assert_eq(findings[0].level, @papion.FindingLevel::Fail)
   assert_eq(findings[0].rule, "sha-pinning")
@@ -83,8 +81,7 @@ test "check_sha_pinning immutable release passes" {
     git_ref: "v4",
     path: None,
   }
-  let policy = @papion.Policy::default()
-  assert_eq(check_sha_pinning(action_ref, ImmutableRelease, policy), [])
+  assert_eq(check_sha_pinning(action_ref, ImmutableRelease), [])
 }
 
 ///|
@@ -95,30 +92,13 @@ test "check_sha_pinning tag ref fails" {
     git_ref: "v4",
     path: None,
   }
-  let policy = @papion.Policy::default()
-  let findings = check_sha_pinning(action_ref, Tag, policy)
+  let findings = check_sha_pinning(action_ref, Tag)
   assert_eq(findings.length(), 1)
   assert_eq(findings[0].rule, "sha-pinning")
   assert_eq(
     findings[0].message,
     "action ref is not pinned to a SHA or immutable release",
   )
-}
-
-///|
-test "check_sha_pinning disabled skips" {
-  let action_ref : @papion.ActionRef = {
-    owner: "actions",
-    repo: "checkout",
-    git_ref: "v4",
-    path: None,
-  }
-  let policy : @papion.Policy = {
-    sha_pinning: false,
-    allowed: [],
-    disallowed: [],
-  }
-  assert_eq(check_sha_pinning(action_ref, Branch, policy), [])
 }
 
 ///|
@@ -129,11 +109,7 @@ test "check_allowed empty list passes all" {
     git_ref: "v4",
     path: None,
   }
-  let policy : @papion.Policy = {
-    sha_pinning: true,
-    allowed: [],
-    disallowed: [],
-  }
+  let policy : @papion.Policy = { allowed: [], disallowed: [] }
   assert_eq(check_allowed(action_ref, policy), [])
 }
 
@@ -145,11 +121,7 @@ test "check_allowed matching pattern passes" {
     git_ref: "v4",
     path: None,
   }
-  let policy : @papion.Policy = {
-    sha_pinning: true,
-    allowed: ["actions/*"],
-    disallowed: [],
-  }
+  let policy : @papion.Policy = { allowed: ["actions/*"], disallowed: [] }
   assert_eq(check_allowed(action_ref, policy), [])
 }
 
@@ -161,11 +133,7 @@ test "check_allowed no match fails" {
     git_ref: "v4",
     path: None,
   }
-  let policy : @papion.Policy = {
-    sha_pinning: true,
-    allowed: ["github/*"],
-    disallowed: [],
-  }
+  let policy : @papion.Policy = { allowed: ["github/*"], disallowed: [] }
   let findings = check_allowed(action_ref, policy)
   assert_eq(findings.length(), 1)
   assert_eq(findings[0].level, @papion.FindingLevel::Fail)
@@ -181,11 +149,7 @@ test "check_disallowed matching pattern fails" {
     git_ref: "v1",
     path: None,
   }
-  let policy : @papion.Policy = {
-    sha_pinning: true,
-    allowed: [],
-    disallowed: ["bad-org/*"],
-  }
+  let policy : @papion.Policy = { allowed: [], disallowed: ["bad-org/*"] }
   let findings = check_disallowed(action_ref, policy)
   assert_eq(findings.length(), 1)
   assert_eq(findings[0].level, @papion.FindingLevel::Fail)
@@ -201,11 +165,7 @@ test "check_disallowed no match passes" {
     git_ref: "v4",
     path: None,
   }
-  let policy : @papion.Policy = {
-    sha_pinning: true,
-    allowed: [],
-    disallowed: ["bad-org/*"],
-  }
+  let policy : @papion.Policy = { allowed: [], disallowed: ["bad-org/*"] }
   assert_eq(check_disallowed(action_ref, policy), [])
 }
 
@@ -259,11 +219,7 @@ test "evaluate non-SHA ref not in allowed list produces two findings" {
     git_ref: "v4",
     path: None,
   }
-  let policy : @papion.Policy = {
-    sha_pinning: true,
-    allowed: ["github/*"],
-    disallowed: [],
-  }
+  let policy : @papion.Policy = { allowed: ["github/*"], disallowed: [] }
   let findings = evaluate(action_ref, Branch, policy)
   assert_eq(findings.length(), 2)
   assert_eq(findings[0].rule, "sha-pinning")
@@ -279,7 +235,6 @@ test "evaluate action in both allowed and disallowed produces disallowed finding
     path: None,
   }
   let policy : @papion.Policy = {
-    sha_pinning: true,
     allowed: ["actions/*"],
     disallowed: ["actions/*"],
   }
@@ -296,8 +251,7 @@ test "check_sha_pinning with path includes path in target" {
     git_ref: "v2",
     path: Some("deploy"),
   }
-  let policy = @papion.Policy::default()
-  let findings = check_sha_pinning(action_ref, Branch, policy)
+  let findings = check_sha_pinning(action_ref, Branch)
   assert_eq(findings.length(), 1)
   assert_eq(findings[0].target, "myorg/actions/deploy@v2")
 }
@@ -310,11 +264,7 @@ test "evaluate with path includes path in finding target" {
     git_ref: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
     path: Some("sub"),
   }
-  let policy : @papion.Policy = {
-    sha_pinning: true,
-    allowed: ["github/*"],
-    disallowed: [],
-  }
+  let policy : @papion.Policy = { allowed: ["github/*"], disallowed: [] }
   let findings = evaluate(action_ref, Sha, policy)
   assert_eq(findings.length(), 1)
   assert_eq(findings[0].rule, "allowed-list")
@@ -333,7 +283,6 @@ test "evaluate all passing produces no findings" {
     path: None,
   }
   let policy : @papion.Policy = {
-    sha_pinning: true,
     allowed: ["actions/*"],
     disallowed: ["bad-org/*"],
   }

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -750,3 +750,32 @@ GitHub announced a major security roadmap for GitHub Actions in 2026, covering:
 ### Strategic implication
 
 Papion's SHA pinning rule for **action-internal dependencies** remains valid. The larger opportunity shifts toward the **policy engine and marketplace**. GitHub is securing the execution layer; Papion owns the **evaluation and discovery** layer.
+
+---
+
+## Decision 22: Make SHA pinning mandatory; remove configurable `sha_pinning` field
+
+### Context
+
+Papion's `sha-pinning` rule was previously gated by a configurable `policy.sha_pinning : Bool` field. Setting it to `false` disabled the rule entirely, allowing users to bypass the core security contract. This created unnecessary branching in the engine (`resolve_ref_kind` was skipped when `sha_pinning = false`), a conditional early-exit in `check_sha_pinning`, and ambiguity about what a "clean" scan actually means.
+
+### Decision
+
+Remove `sha_pinning` from `Policy`. SHA pinning is now always enforced.
+
+* `Policy` contains only `allowed` and `disallowed`.
+* `check_sha_pinning` no longer receives a `Policy` argument.
+* The engine always calls `resolve_ref_kind` unconditionally.
+* Config parsers (JSON and TOML) silently ignore a `sha_pinning` key if present, so old config files remain valid without producing an error.
+
+### Rationale
+
+* SHA pinning is Papion's minimum security floor, not an optional feature. A scanner that lets users skip it undermines its own purpose.
+* Removing the toggle simplifies all conditional code paths.
+* Silent ignore (rather than hard error or deprecation warning) keeps old configs working without a migration step, consistent with being pre-1.0.
+
+### Consequences
+
+* **Breaking change**: `Policy` struct drops one field. Any code constructing a `Policy` literal with `sha_pinning` must remove that field.
+* Old TOML/JSON configs with `sha_pinning = false` silently start enforcing SHA pinning.
+* `check_sha_pinning` signature: `(ActionRef, RefKind)` — no policy parameter.


### PR DESCRIPTION
## Summary

- Removes `sha_pinning : Bool` from `Policy` — SHA pinning is now always enforced, not configurable.
- `check_sha_pinning` signature drops the `policy` parameter (it was unused once the early-exit was removed).
- The engine unconditionally calls `resolve_ref_kind` for all refs (no more conditional skip when `sha_pinning = false`).
- Config parsers (JSON and TOML) **silently ignore** a legacy `sha_pinning` key so existing config files continue to work without any migration step.
- Deletes 3 tests that existed solely to exercise the disabled-SHA-pinning code path.
- Adds a `parse_policy ignores legacy sha_pinning field` test to document the silent-ignore contract.
- ADR Decision 22 documents the rationale and back-compat behaviour.

Closes #51.

## Breaking change

`Policy` no longer has a `sha_pinning` field. Any code constructing a `Policy` literal with `sha_pinning:` must drop that field. Old TOML/JSON configs with `sha_pinning = false` will silently start enforcing SHA pinning.

## Test plan

- [x] `moon test --target native` — 275 passed, 0 failed
- [x] `moon fmt --check` — clean
- [x] `moon info && git diff --ignore-blank-lines --exit-code -- '*.mbti'` — only expected changes to `core/pkg.generated.mbti` and `core/rules/pkg.generated.mbti`

🤖 Generated with [Claude Code](https://claude.com/claude-code)