### PR TITLE
feat(action): add setup-papion composite action (closes #81)

### DIFF
--- a/.github/workflows/test-setup-papion.yml
+++ b/.github/workflows/test-setup-papion.yml
@@ -1,0 +1,34 @@
+name: Test setup-papion
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'action/setup-papion/**'
+      - '.github/workflows/test-setup-papion.yml'
+  pull_request:
+    paths:
+      - 'action/setup-papion/**'
+      - '.github/workflows/test-setup-papion.yml'
+
+jobs:
+  smoke:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - id: setup
+        uses: ./action/setup-papion
+      - run: papion --version
+      - name: Confirm version output matches vX.Y.Z
+        env:
+          INSTALLED_VERSION: ${{ steps.setup.outputs.version }}
+        run: |
+          set -euo pipefail
+          case "$INSTALLED_VERSION" in
+            v[0-9]*.[0-9]*.[0-9]*) ;;
+            *) echo "::error::Unexpected version output: $INSTALLED_VERSION"; exit 1;;
+          esac

--- a/.tagpr
+++ b/.tagpr
@@ -4,4 +4,4 @@
 	# the publish job in release.yml. tagpr must not create it.
 	release = false
 	changelog = true
-	versionFile = action/setup-papion/action.yml;regexp=\bdefault:\s+([0-9]+\.[0-9]+\.[0-9]+)
+	versionFile = action/setup-papion/action.yml

--- a/.tagpr
+++ b/.tagpr
@@ -4,3 +4,4 @@
 	# the publish job in release.yml. tagpr must not create it.
 	release = false
 	changelog = true
+	versionFile = action/setup-papion/action.yml;regexp=\bdefault:\s+([0-9]+\.[0-9]+\.[0-9]+)

--- a/README.md
+++ b/README.md
@@ -189,44 +189,19 @@ papion run actions/checkout@v4 --format json
 
 ## GitHub Action
 
-Add Papion to your workflow as an action maintainer to scan your own action on every push.
-
-By default it scans the current repository at the current commit ref. You can override the ref with the `ref` input.
+Use `setup-papion` to install the Papion CLI on a runner, then invoke it with `run:`.
 
 ```yaml
-# .github/workflows/papion.yml
-name: Papion
-
-on:
-  push:
-    branches: [main]
-  schedule:
-    - cron: '0 0 * * 1'  # weekly
-
 jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-
-      - uses: maruloop/papion/action@v1
+      - uses: maruloop/papion/action/setup-papion@v1
+      - run: papion run "${{ github.repository }}@${{ github.sha }}"
 ```
 
-Override the ref to scan a specific tag or SHA:
-
-```yaml
-      - uses: maruloop/papion/action@v1
-        with:
-          ref: v2.1.0
-```
-
-### Inputs
-
-| Input | Required | Description |
-|-------|----------|-------------|
-| `ref` | no | Ref to scan (default: current commit SHA) |
-| `format` | no | Output format: `human` (default) or `json` |
-| `fail-on` | no | Minimum level to fail the job: `warn` or `fail` (default: `fail`) |
+Pin to a specific version with `with: version: vX.Y.Z`. See [`action/setup-papion/README.md`](action/setup-papion/README.md) for the full inputs/outputs reference.
 
 ---
 

--- a/action/setup-papion/README.md
+++ b/action/setup-papion/README.md
@@ -1,0 +1,68 @@
+# setup-papion
+
+Install the [Papion](https://github.com/maruloop/papion) CLI on a GitHub Actions runner and add it to `PATH`. This action only installs — it does not run a scan. Compose it with your own `run:` steps.
+
+## Usage
+
+```yaml
+- uses: maruloop/papion/action/setup-papion@v1
+
+- run: papion run actions/checkout@v4
+```
+
+Pin to a specific version:
+
+```yaml
+- uses: maruloop/papion/action/setup-papion@v1
+  with:
+    version: v0.2.0
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `version` | no | `latest` | Papion version to install. Accepts `latest`, `vX.Y.Z`, or `X.Y.Z`. |
+| `github-token` | no | `${{ github.token }}` | Token used for the GitHub Releases API call (resolving `latest`) and for the tarball download. |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `version` | The resolved release tag that was installed (e.g. `v0.2.0`). |
+
+## Supported runners
+
+| Runner | Status |
+|--------|--------|
+| `ubuntu-*` (x86_64) | ✅ |
+| `macos-14`+ (arm64) | ✅ |
+| `windows-*` | ❌ not yet supported |
+| Linux arm64 | ❌ not yet supported |
+| macOS x86_64 (Intel) | ❌ not yet supported |
+
+On unsupported runners the action fails immediately with a clear error message.
+
+## Example: scan on every push
+
+```yaml
+name: Papion
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: maruloop/papion/action/setup-papion@v1
+      - run: papion run "${{ github.repository }}@${{ github.sha }}"
+```
+
+## Notes
+
+- The action downloads `papion-<os>-<arch>.tar.gz` from the matching [GitHub Release](https://github.com/maruloop/papion/releases), extracts the binary, and prepends its directory to `$GITHUB_PATH`.
+- Checksum verification is not yet performed (follow-up: publish `.sha256` files from the release pipeline).
+- Caching is not performed at this version. The binary is small; re-download per job is intentional.

--- a/action/setup-papion/README.md
+++ b/action/setup-papion/README.md
@@ -10,7 +10,7 @@ Install the [Papion](https://github.com/maruloop/papion) CLI on a GitHub Actions
 - run: papion run actions/checkout@v4
 ```
 
-Pin to a specific version:
+The `version` input defaults to the release that the action was tagged from. You can override it to install a different version:
 
 ```yaml
 - uses: maruloop/papion/action/setup-papion@v1
@@ -22,14 +22,13 @@ Pin to a specific version:
 
 | Input | Required | Default | Description |
 |-------|----------|---------|-------------|
-| `version` | no | current release | Papion version to install. Accepts `latest`, `vX.Y.Z`, or `X.Y.Z`. The default is rewritten to the concrete release version by the release pipeline. |
-| `github-token` | no | `${{ github.token }}` | Token used for the GitHub Releases API call (resolving `latest`) and for the tarball download. |
+| `version` | no | current release | Papion version to install. Accepts `vX.Y.Z` or `X.Y.Z`. Must be pinned to an explicit release tag — `latest` is not accepted. The default is rewritten to the concrete release tag by the release pipeline. |
 
 ## Outputs
 
 | Output | Description |
 |--------|-------------|
-| `version` | The resolved release tag that was installed (e.g. `v0.2.0`). |
+| `version` | The release tag that was installed (e.g. `v0.2.0`). |
 
 ## Supported runners
 
@@ -64,5 +63,6 @@ jobs:
 ## Notes
 
 - The action downloads `papion-<os>-<arch>.tar.gz` from the matching [GitHub Release](https://github.com/maruloop/papion/releases), extracts the binary, and prepends its directory to `$GITHUB_PATH`.
+- `latest` is intentionally not accepted as a version value. Pinning to an explicit tag is required for reproducibility and supply-chain safety.
 - Checksum verification is not yet performed (follow-up: publish `.sha256` files from the release pipeline).
 - Caching is not performed at this version. The binary is small; re-download per job is intentional.

--- a/action/setup-papion/README.md
+++ b/action/setup-papion/README.md
@@ -22,7 +22,7 @@ Pin to a specific version:
 
 | Input | Required | Default | Description |
 |-------|----------|---------|-------------|
-| `version` | no | `latest` | Papion version to install. Accepts `latest`, `vX.Y.Z`, or `X.Y.Z`. |
+| `version` | no | current release | Papion version to install. Accepts `latest`, `vX.Y.Z`, or `X.Y.Z`. The default is rewritten to the concrete release version by the release pipeline. |
 | `github-token` | no | `${{ github.token }}` | Token used for the GitHub Releases API call (resolving `latest`) and for the tarball download. |
 
 ## Outputs

--- a/action/setup-papion/action.yml
+++ b/action/setup-papion/action.yml
@@ -2,13 +2,9 @@ name: Setup Papion
 description: Install the Papion CLI on the runner and add it to PATH.
 inputs:
   version:
-    description: 'Papion version to install. Accepts "latest", "vX.Y.Z", or "X.Y.Z".'
+    description: 'Papion version to install. Accepts "vX.Y.Z" or "X.Y.Z". Must be pinned explicitly.'
     required: false
     default: 0.0.0
-  github-token:
-    description: Token used for the GitHub Releases API call and tarball download.
-    required: false
-    default: ${{ github.token }}
 outputs:
   version:
     description: Resolved release tag that was installed (e.g. v0.2.0).
@@ -20,7 +16,6 @@ runs:
       shell: bash
       env:
         INPUT_VERSION: ${{ inputs.version }}
-        GH_TOKEN: ${{ inputs.github-token }}
       run: |
         set -euo pipefail
 
@@ -107,22 +102,15 @@ runs:
         esac
 
         if [ "$version" = "latest" ]; then
-          tag="$(curl -fsSL --retry 3 \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            https://api.github.com/repos/maruloop/papion/releases/latest \
-            | jq -r '.tag_name')"
-          if [ -z "$tag" ] || [ "$tag" = "null" ]; then
-            echo "::error::setup-papion: could not resolve latest release tag"
-            exit 1
-          fi
-        else
-          # Normalise X.Y.Z → vX.Y.Z.
-          case "$version" in
-            v*) tag="$version" ;;
-            *)  tag="v$version" ;;
-          esac
+          echo "::error::setup-papion: version \"latest\" is not accepted. Pin to an explicit release tag (e.g. vX.Y.Z)."
+          exit 1
         fi
+
+        # Normalise X.Y.Z → vX.Y.Z.
+        case "$version" in
+          v*) tag="$version" ;;
+          *)  tag="v$version" ;;
+        esac
 
         # Validate resolved tag (defence in depth against API tampering).
         case "$tag" in
@@ -173,7 +161,6 @@ runs:
 
         echo "::group::Download papion ${tag} (${platform})"
         curl -fsSL --retry 3 \
-          -H "Authorization: Bearer $GH_TOKEN" \
           -o "$tmpdir/$artifact" \
           "$download_url"
         echo "::endgroup::"

--- a/action/setup-papion/action.yml
+++ b/action/setup-papion/action.yml
@@ -1,0 +1,201 @@
+name: Setup Papion
+description: Install the Papion CLI on the runner and add it to PATH.
+inputs:
+  version:
+    description: 'Papion version to install. Accepts "latest", "vX.Y.Z", or "X.Y.Z".'
+    required: false
+    default: latest
+  github-token:
+    description: Token used for the GitHub Releases API call and tarball download.
+    required: false
+    default: ${{ github.token }}
+outputs:
+  version:
+    description: Resolved release tag that was installed (e.g. v0.2.0).
+    value: ${{ steps.install.outputs.version }}
+runs:
+  using: composite
+  steps:
+    - id: install
+      shell: bash
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: |
+        set -euo pipefail
+
+        make_temp_dir() {
+          local dir
+          if dir="$(mktemp -d 2>/dev/null)"; then
+            printf '%s\n' "$dir"
+            return 0
+          fi
+          mktemp -d -t papion-setup
+        }
+
+        validate_tar_archive() {
+          local archive="$1"
+          local validate_dir
+          validate_dir="$(make_temp_dir)"
+          if ! tar -tzf "$archive" > "$validate_dir/paths"; then
+            echo "::error::Failed to list archive paths in $archive"
+            rm -rf "$validate_dir"
+            return 1
+          fi
+          if ! tar -tvzf "$archive" > "$validate_dir/metadata"; then
+            echo "::error::Failed to inspect archive metadata in $archive"
+            rm -rf "$validate_dir"
+            return 1
+          fi
+
+          local entry
+          local normalized_entry
+          while IFS= read -r entry; do
+            normalized_entry="$entry"
+            while [[ "$normalized_entry" == ./* ]]; do
+              normalized_entry="${normalized_entry#./}"
+            done
+            case "$normalized_entry" in
+              /*|../*|*/../*|..|*/..)
+                echo "::error::Unsafe archive entry '$entry' in $archive"
+                rm -rf "$validate_dir"
+                return 1
+                ;;
+            esac
+          done < "$validate_dir/paths"
+
+          local metadata
+          local type
+          while IFS= read -r metadata; do
+            type="${metadata:0:1}"
+            case "$type" in
+              d|-|x|g|L|K)
+                ;;
+              *)
+                echo "::error::Unsupported archive entry type '$type' in $archive: $metadata"
+                rm -rf "$validate_dir"
+                return 1
+                ;;
+            esac
+          done < "$validate_dir/metadata"
+
+          rm -rf "$validate_dir"
+        }
+
+        reject_symlinks() {
+          local root="$1"
+          local label="$2"
+          local link
+          link="$(find "$root" -type l -print -quit)"
+          if [ -n "$link" ]; then
+            echo "::error::Unexpected symlink in $label: $link"
+            return 1
+          fi
+        }
+
+        # Validate and normalise the requested version.
+        version="$INPUT_VERSION"
+        if [ -z "$version" ]; then
+          echo "::error::setup-papion: version input must not be empty"
+          exit 1
+        fi
+        case "$version" in
+          *[!A-Za-z0-9._+-]*|*..*)
+            echo "::error::setup-papion: invalid version string: $version"
+            exit 1
+            ;;
+        esac
+
+        if [ "$version" = "latest" ]; then
+          tag="$(curl -fsSL --retry 3 \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/maruloop/papion/releases/latest \
+            | jq -r '.tag_name')"
+          if [ -z "$tag" ] || [ "$tag" = "null" ]; then
+            echo "::error::setup-papion: could not resolve latest release tag"
+            exit 1
+          fi
+        else
+          # Normalise X.Y.Z → vX.Y.Z.
+          case "$version" in
+            v*) tag="$version" ;;
+            *)  tag="v$version" ;;
+          esac
+        fi
+
+        # Validate resolved tag (defence in depth against API tampering).
+        case "$tag" in
+          *[!A-Za-z0-9._+-]*|*..*)
+            echo "::error::setup-papion: resolved tag contains unsafe characters: $tag"
+            exit 1
+            ;;
+        esac
+
+        # Detect platform and map to release asset name.
+        case "$(uname -s)" in
+          Linux)  os="linux"  ;;
+          Darwin) os="macos"  ;;
+          *)
+            echo "::error::setup-papion: unsupported OS: $(uname -s). See supported runners: https://github.com/maruloop/papion/tree/main/action/setup-papion#supported-runners"
+            exit 1
+            ;;
+        esac
+
+        case "$(uname -m)" in
+          x86_64|amd64)
+            if [ "$os" = "linux" ]; then
+              platform="linux-x64"
+            else
+              echo "::error::setup-papion: macOS x86_64 (Intel) is not yet supported. See: https://github.com/maruloop/papion/tree/main/action/setup-papion#supported-runners"
+              exit 1
+            fi
+            ;;
+          arm64|aarch64)
+            if [ "$os" = "macos" ]; then
+              platform="macos-arm64"
+            else
+              echo "::error::setup-papion: Linux arm64 is not yet supported. See: https://github.com/maruloop/papion/tree/main/action/setup-papion#supported-runners"
+              exit 1
+            fi
+            ;;
+          *)
+            echo "::error::setup-papion: unsupported architecture: $(uname -m). See: https://github.com/maruloop/papion/tree/main/action/setup-papion#supported-runners"
+            exit 1
+            ;;
+        esac
+
+        artifact="papion-${platform}.tar.gz"
+        download_url="https://github.com/maruloop/papion/releases/download/${tag}/${artifact}"
+
+        tmpdir="$(make_temp_dir)"
+        trap 'rm -rf "$tmpdir"' EXIT
+
+        echo "::group::Download papion ${tag} (${platform})"
+        curl -fsSL --retry 3 \
+          -H "Authorization: Bearer $GH_TOKEN" \
+          -o "$tmpdir/$artifact" \
+          "$download_url"
+        echo "::endgroup::"
+
+        validate_tar_archive "$tmpdir/$artifact"
+
+        extract_dir="$tmpdir/extract"
+        mkdir -p "$extract_dir"
+        tar -xzf "$tmpdir/$artifact" -C "$extract_dir"
+        reject_symlinks "$extract_dir" "papion archive"
+
+        if [ ! -f "$extract_dir/papion" ]; then
+          echo "::error::setup-papion: could not locate papion binary in $artifact"
+          exit 1
+        fi
+
+        install_dir="$RUNNER_TEMP/papion-bin"
+        mkdir -p "$install_dir"
+        cp "$extract_dir/papion" "$install_dir/papion"
+        chmod +x "$install_dir/papion"
+
+        echo "$install_dir" >> "$GITHUB_PATH"
+
+        "$install_dir/papion" --version
+        echo "version=${tag}" >> "$GITHUB_OUTPUT"

--- a/action/setup-papion/action.yml
+++ b/action/setup-papion/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: 'Papion version to install. Accepts "latest", "vX.Y.Z", or "X.Y.Z".'
     required: false
-    default: latest
+    default: 0.0.0
   github-token:
     description: Token used for the GitHub Releases API call and tarball download.
     required: false

--- a/docs/adr.md
+++ b/docs/adr.md
@@ -779,3 +779,33 @@ Remove `sha_pinning` from `Policy`. SHA pinning is now always enforced.
 * **Breaking change**: `Policy` struct drops one field. Any code constructing a `Policy` literal with `sha_pinning` must remove that field.
 * Old TOML/JSON configs with `sha_pinning = false` silently start enforcing SHA pinning.
 * `check_sha_pinning` signature: `(ActionRef, RefKind)` — no policy parameter.
+
+---
+
+## Decision 23: Ship `setup-papion` as an install-only composite action, separate from a future run action
+
+### Context
+
+Papion's release pipeline publishes `papion-<os>-<arch>.tar.gz` tarballs to GitHub Releases. Users wanting to invoke Papion from a workflow had to `curl | tar` manually. The original v1.0.0 plan (#11) tracks a single "run papion" action, but conflating install and invocation forces a combined inputs surface and prevents users from composing Papion with custom invocation patterns (multiple targets, scripted argument construction, conditional execution).
+
+### Decision
+
+Ship a dedicated `setup-papion` composite action at `action/setup-papion/` whose sole responsibility is to place the `papion` binary on `$GITHUB_PATH`. It does not execute a scan. A separate "run papion" action (#11) remains a future addition.
+
+* Inputs: `version` (default `latest`; accepts `latest`, `vX.Y.Z`, or `X.Y.Z`), `github-token` (default `${{ github.token }}`).
+* Output: `version` — the resolved tag actually installed.
+* Behavior: resolve version, detect platform, download tarball, validate, extract, install to `$RUNNER_TEMP/papion-bin/`, append to `$GITHUB_PATH`, verify with `papion --version`.
+* Platforms at v1: `linux-x64` and `macos-arm64` only. Other runners fail with a clear error.
+
+### Rationale
+
+* **Composability over configurability.** `setup-go` / `setup-node` set the precedent: install once, then let users write `run:` steps with their own arguments.
+* **No new release-pipeline coupling.** The action consumes existing tarballs as-is. Checksum verification is deferred until `.sha256` files are published from `release.yml`.
+* **Matches the runtime story.** Papion is a native binary (Decision 18); a composite action that downloads and runs it is the simplest possible packaging — no Docker pull, no JS runtime.
+
+### Consequences
+
+* `action/setup-papion/action.yml` is the user-facing entry point; users reference it as `maruloop/papion/action/setup-papion@v1`.
+* The future "run papion" action (#11) layers on top of `setup-papion` rather than reimplementing install logic.
+* Two follow-up issues are implied: (a) publish per-asset checksums from `release.yml` and verify them in the action; (b) extend the release matrix to Windows, `linux-arm64`, and `macos-x64`.
+* Caching is intentionally omitted at v1.


### PR DESCRIPTION
## Summary

- Adds `action/setup-papion/action.yml` — a composite action that installs the Papion native binary on the runner and adds it to `PATH`
- Mirrors the hardening conventions from `.github/actions/setup-moonbit`: path-traversal validation, symlink rejection, version-string sanitisation, `set -euo pipefail`, `::error::` annotations
- Supports `linux-x64` and `macos-arm64`; fails with a clear, actionable error on other platforms
- Adds `.github/workflows/test-setup-papion.yml` smoke-test on `ubuntu-latest` + `macos-14`
- Updates top-level `README.md` GitHub Action section to reference the new action
- Adds ADR Decision 23 documenting the install-only / separate-from-run-action design

## What's not in scope

- Checksum verification (releases don't publish `.sha256` yet — follow-up issue)
- Caching (binary is small; intentionally deferred)
- Windows / `linux-arm64` / `macos-x64` builds (extend release matrix separately)

## Test plan

- [ ] CI runs `test-setup-papion.yml` on `ubuntu-latest` and `macos-14`
- [ ] `papion --version` succeeds on both
- [ ] `version` output matches `vX.Y.Z`
- [ ] `bash -n` syntactic check on the script body passes locally ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)